### PR TITLE
Image and Shadow Theme dev

### DIFF
--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -42,13 +42,13 @@
       </div>  
       <main>
         <section id="header" class="content">
-          <p>Hi, my name is</p>
+          <h3>Hi, my name is</h3>
           <h1>Zach Ghera</h1>
         </section>
     
         <section id="about" class="content">
           <h2>About Me</h2>
-          <img src="images/zghera-wide.jpg" alt="Me">
+          <img src="images/zghera-wide.jpg" alt="Me"  class="pic">
           <p>Hello there! I'm Zach, a rising junior at Purdue University studying
             Computer Engineering.</p>
           <p>I have a passion for technology and solving complex problems through 
@@ -64,7 +64,7 @@
             <h3>STEP Intern @ Google</h3>
             <h4>May - Aug 2020</h4>
             <p>...</p>
-            <img src="images/trips.png" alt="Google Trips Logo">
+            <img src="images/trips.png" alt="Google Trips Logo" class="pic">
           </section>
           <section class="content">
             <h3>EP Intern @ Google</h3>
@@ -87,7 +87,7 @@
                 performance reduction.
               </li>
             </ul>
-            <img src="images/g-plat-logo.png" alt="Google Platforms Logo">
+            <img src="images/g-plat-logo.png" alt="Google Platforms Logo" class="pic">
           </section>
           <section class="content">
             <h3>CSSI Student @ Google</h3>
@@ -106,7 +106,7 @@
                 Python's email module.
               </li>
             </ul>
-            <img src="images/CSSI-wireframe.png" alt="CSSI Web App Wireframe">
+            <img src="images/CSSI-wireframe.png" alt="CSSI Web App Wireframe" class="pic">
           </section>
         </section>
  
@@ -126,7 +126,7 @@
                 structure for the organization. 
               </li>
             </ul>
-            <img src="images/amp2.jpg" alt="AMP 2D Kart Simulation">
+            <img src="images/amp2.jpg" alt="AMP 2D Kart Simulation" class="pic">
           </section>
           <section class="content">
             <h3>IEEE ROV</h3>
@@ -135,7 +135,7 @@
               path, performed image recognition (filtering, moment identification, line 
               transforms, etc.), and published control output to a ROS topic.
             </p>
-            <img src="images/rov.png" alt="Species Recognition Functionality">
+            <img src="images/rov.png" alt="Species Recognition Functionality" class="pic">
           </section>
           <section class="content">
             <h3>Engineering Design</h3>
@@ -151,13 +151,13 @@
                 and map a maze while avoiding hazards. 
               </li>
             </ul>
-            <img src="images/engr161.png" alt="Mars Rover Prototype Robot">
+            <img src="images/engr161.png" alt="Mars Rover Prototype Robot" class="pic">
           </section>
         </section>
         <section id="contact" class="content">
           <h2>Get In Touch</h4>
           <p>...</p>
-          <a style="padding-bottom:20vh" href="mailto:zachary.ghera@gmail.com" id="link-box">Say Hi</a>
+          <a style="padding-bottom:20vh" href="mailto:zachary.ghera@gmail.com" class="link-box">Say Hi</a>
         </section>
       </main>
     </div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -48,7 +48,7 @@
     
         <section id="about" class="content">
           <h2>About Me</h2>
-          <img src="images/zghera-wide.jpg" alt="Me"  class="pic">
+          <img src="images/zghera-wide.jpg" alt="Me">
           <p>Hello there! I'm Zach, a rising junior at Purdue University studying
             Computer Engineering.</p>
           <p>I have a passion for technology and solving complex problems through 
@@ -123,7 +123,7 @@
                 structure for the organization. 
               </li>
             </ul>
-            <img src="images/amp2.jpg" alt="AMP 2D Kart Simulation" class="pic">
+            <img src="images/amp2.jpg" alt="AMP 2D Kart Simulation">
           </section>
           <section class="content">
             <h3>IEEE ROV</h3>
@@ -132,7 +132,7 @@
               path, performed image recognition (filtering, moment identification, line 
               transforms, etc.), and published control output to a ROS topic.
             </p>
-            <img src="images/rov.png" alt="Species Recognition Functionality" class="pic">
+            <img src="images/rov.png" alt="Species Recognition Functionality">
           </section>
           <section class="content">
             <h3>Engineering Design</h3>
@@ -148,7 +148,7 @@
                 and map a maze while avoiding hazards. 
               </li>
             </ul>
-            <img src="images/engr161.png" alt="Mars Rover Prototype Robot" class="pic">
+            <img src="images/engr161.png" alt="Mars Rover Prototype Robot">
           </section>
         </section>
         <section id="contact" class="content">

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -64,7 +64,6 @@
             <h3>STEP Intern @ Google</h3>
             <h4>May - Aug 2020</h4>
             <p>...</p>
-            <img src="images/trips.png" alt="Google Trips Logo" class="pic">
           </section>
           <section class="content">
             <h3>EP Intern @ Google</h3>
@@ -87,7 +86,6 @@
                 performance reduction.
               </li>
             </ul>
-            <img src="images/g-plat-logo.png" alt="Google Platforms Logo" class="pic">
           </section>
           <section class="content">
             <h3>CSSI Student @ Google</h3>
@@ -106,7 +104,6 @@
                 Python's email module.
               </li>
             </ul>
-            <img src="images/CSSI-wireframe.png" alt="CSSI Web App Wireframe" class="pic">
           </section>
         </section>
  

--- a/portfolio/src/main/webapp/scripts/script.js
+++ b/portfolio/src/main/webapp/scripts/script.js
@@ -14,5 +14,5 @@
 
 /* TODO:Format */
 function reload(){
-  window.open("https://8080-dot-12459592-dot-devshell.appspot.com/","_self");
+  window.open("index.html","_self");
 }

--- a/portfolio/src/main/webapp/styles/style.css
+++ b/portfolio/src/main/webapp/styles/style.css
@@ -4,10 +4,6 @@ body {
   background-color: #41485B;
 }
 
-#header {
-  padding-top: 14vh;
-}
-
 h1 {
   font-family: 'Roboto', sans-serif;
 }
@@ -22,10 +18,18 @@ h1 {
 .section {
   padding-top: 30vw;
 }
- 
-img {
-  height: 10%;
-  width: 10%;
+
+.pic {
+  object-fit: fill;
+  width:30vw;
+  height:17vw;
+  border:solid;
+  border-color:rgb(40,40,250,.5);
+  box-shadow:5px 5px 20px rgb(40,40,250,.5);
+}
+
+#header {
+  padding-top: 11vmax;
 }
  
 /* Top Navigation Bar */
@@ -40,12 +44,12 @@ img {
   position: fixed;
   top: 0;
   width: 100vw;
+  z-index:2;
 }
 
 #home-logo {
   background:rgb(40,40,60);
   border:solid;
-  border-color:black;
   border-radius:50%;
   color: #008BB3;
   font-size: 2em;
@@ -55,9 +59,12 @@ img {
   text-decoration: none;
   width:75px;
   z-index:3;
+  border-color:rgb(40,40,250,.5);
+  box-shadow:5px 5px 20px rgb(40,40,250,.5);
+  text-shadow:5px 5px 20px #008BB3;
 }
 
-#home-logo:hover{
+#home-logo:hover {
   background:rgb(60,60,80);
   border-color:rgb(100,100,200);
   color: #18a5d4;
@@ -89,10 +96,13 @@ img {
   display: block;
   text-align: center;
   text-decoration: none;
+  height:5vw;
+  padding-top:2vw;
 }
  
 .nav-lnk:hover {
-  color: white;
+  color:white;
+  text-shadow:0px 0px 20px blue;
 }
 
 /* Side Bar */
@@ -158,4 +168,8 @@ img {
   color:rgb(160, 160, 160) !important;
   opacity:1 !important;
   z-index:3;
+}
+
+#sidebar > div > a:hover {
+  box-shadow:0px 0px 20px rgb(40,40,250,.7);
 }

--- a/portfolio/src/main/webapp/styles/style.css
+++ b/portfolio/src/main/webapp/styles/style.css
@@ -85,7 +85,7 @@ h1 {
   justify-content: flex-end;
 }
  
-#inner-nav-container > div{
+#inner-nav-container > div {
   align-self: center;
   flex-basis: 10%;
   padding-right: 3%;

--- a/portfolio/src/main/webapp/styles/style.css
+++ b/portfolio/src/main/webapp/styles/style.css
@@ -20,12 +20,12 @@ h1 {
 }
 
 .pic {
-  object-fit: fill;
-  width:30vw;
-  height:17vw;
   border:solid;
   border-color:rgb(40,40,250,.5);
   box-shadow:5px 5px 20px rgb(40,40,250,.5);
+  height:17vw;
+  object-fit: fill;
+  width:30vw;
 }
 
 #header {
@@ -50,18 +50,18 @@ h1 {
 #home-logo {
   background:rgb(40,40,60);
   border:solid;
+  border-color:rgb(40,40,250,.5);
   border-radius:50%;
+  box-shadow:5px 5px 20px rgb(40,40,250,.5);
   color: #008BB3;
   font-size: 2em;
   height:60px;
   padding-top:15px;
   text-align: center;
   text-decoration: none;
+  text-shadow:5px 5px 20px #008BB3;
   width:75px;
   z-index:3;
-  border-color:rgb(40,40,250,.5);
-  box-shadow:5px 5px 20px rgb(40,40,250,.5);
-  text-shadow:5px 5px 20px #008BB3;
 }
 
 #home-logo:hover {

--- a/portfolio/src/main/webapp/styles/style.css
+++ b/portfolio/src/main/webapp/styles/style.css
@@ -4,6 +4,15 @@ body {
   background-color: #41485B;
 }
 
+img {
+  border:solid;
+  border-color:rgb(40,40,250,.5);
+  box-shadow:5px 5px 20px rgb(40,40,250,.5);
+  height:17vw;
+  object-fit: fill;
+  width:30vw;
+}
+
 h1 {
   font-family: 'Roboto', sans-serif;
 }
@@ -13,19 +22,6 @@ h1 {
   padding-top: 2vh;
   padding-left: 12vw;
   z-index:0;
-}
- 
-.section {
-  padding-top: 30vw;
-}
-
-.pic {
-  border:solid;
-  border-color:rgb(40,40,250,.5);
-  box-shadow:5px 5px 20px rgb(40,40,250,.5);
-  height:17vw;
-  object-fit: fill;
-  width:30vw;
 }
 
 #header {
@@ -47,6 +43,7 @@ h1 {
   z-index:2;
 }
 
+/* Left flex element of 'outer-nav' container */
 #home-logo {
   background:rgb(40,40,60);
   border:solid;
@@ -71,7 +68,7 @@ h1 {
   cursor:grab;
 }
 
-/* Right-side Nav Flex Element */
+/* Right flex element of 'outer-nav' container */
 .inner-nav-el {
   flex-basis: 80vw;
   font-size: auto;
@@ -84,7 +81,8 @@ h1 {
   flex-flow: row wrap;
   justify-content: flex-end;
 }
- 
+
+/* Child elements of 'inner-nav-container' */
 #inner-nav-container > div {
   align-self: center;
   flex-basis: 10%;


### PR DESCRIPTION
Extension of PR #5. Added a consistent shadow theme to all images, home-logo, and navigation bar elements. Images also resized to reasonable amount for each section. Removed pictures in "Work Experience" section to avoid issues with Google trademark and having to ask for permission to use the logos.

Before:
![before](https://user-images.githubusercontent.com/39711376/83337558-8b088780-a28a-11ea-8ba7-3b0cf11f6b6e.png)

After:
![after-wide](https://user-images.githubusercontent.com/39711376/83337557-8a6ff100-a28a-11ea-90fa-09843cd26b4e.png)
![after-logo-shadow](https://user-images.githubusercontent.com/39711376/83337555-8a6ff100-a28a-11ea-89ee-6d5326ea982a.png)
![after-sidebar-icons-shadow](https://user-images.githubusercontent.com/39711376/83337556-8a6ff100-a28a-11ea-93b9-c2d76e4c614e.png)




