### PR TITLE
Step 6: Specify the Number of Comments

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -48,7 +48,7 @@
         <artifactId>appengine-maven-plugin</artifactId>
         <version>2.2.0</version>
         <configuration>
-          <deploy.projectId>zghera-step-2020</deploy.projectId>
+          <deploy.projectId>zghera-step-2020-v1</deploy.projectId>
           <deploy.version>1</deploy.version>
         </configuration>
       </plugin>

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentsServlet.java
@@ -35,13 +35,10 @@ public class ListCommentsServlet extends HttpServlet {
   private static DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
   /**
-   * This Method handles GET requests in order to display all of the comments that are stored in the
+   * {@inheritDoc}
+   * 
+   * <p>This Method handles GET requests in order to display all of the comments that are stored in the
    * Comments kind of the Google Cloud Datastore.
-   *
-   * @param request The <code>HttpServletRequest</code> for the GET request.
-   * @param response The <code>HttpServletResponse</code> for the GET request.
-   * @return None. The Servlet writes to the /comment-data page which JavaScript then fetches in
-   *     order to serve the comments to the UI.
    */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentsServlet.java
@@ -38,8 +38,6 @@ public class ListCommentsServlet extends HttpServlet {
    * This Method handles GET requests in order to display all of the comments that are stored in the
    * Comments kind of the Google Cloud Datastore.
    *
-   * <p>
-   *
    * @param request The <code>HttpServletRequest</code> for the GET request.
    * @param response The <code>HttpServletResponse</code> for the GET request.
    * @return None. The Servlet writes to the /comment-data page which JavaScript then fetches in
@@ -63,8 +61,6 @@ public class ListCommentsServlet extends HttpServlet {
 
   /**
    * Converts a list of strings to a JSON string.
-   *
-   * <p>
    *
    * @param comments The List of String comments that should be converted to a JSON string.
    * @return <code>String</code> The JSON string corresponding to the list of comments.

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentsServlet.java
@@ -22,8 +22,8 @@ import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.gson.Gson;
 import java.io.IOException;
-import java.util.List; 
 import java.util.ArrayList;
+import java.util.List;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -35,21 +35,22 @@ public class ListCommentsServlet extends HttpServlet {
   private static DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
   /**
-  * This Method handles GET requests in order to display all of the comments that are stored 
-  * in the Comments kind of the Google Cloud Datastore.
-  * <p>
-  * 
-  * @param  request  The <code>HttpServletRequest</code> for the GET request.
-  * @param  response The <code>HttpServletResponse</code> for the GET request.
-  * @return None. The Servlet writes to the /comment-data page which JavaScript then fetches 
-  *         in order to serve the comments to the UI. 
-  */
+   * This Method handles GET requests in order to display all of the comments that are stored in the
+   * Comments kind of the Google Cloud Datastore.
+   *
+   * <p>
+   *
+   * @param request The <code>HttpServletRequest</code> for the GET request.
+   * @param response The <code>HttpServletResponse</code> for the GET request.
+   * @return None. The Servlet writes to the /comment-data page which JavaScript then fetches in
+   *     order to serve the comments to the UI.
+   */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
     PreparedQuery results = datastore.prepare(query);
 
-    List<String> comments = new ArrayList<>();  
+    List<String> comments = new ArrayList<>();
     for (Entity commentEntity : results.asIterable()) {
       String comment = (String) commentEntity.getProperty("text");
       comments.add(comment);
@@ -61,12 +62,13 @@ public class ListCommentsServlet extends HttpServlet {
   }
 
   /**
-  * Converts a list of strings to a JSON string.
-  * <p>
-  *
-  * @param  comments  The List of String comments that should be converted to a JSON string.
-  * @return <code>String</code> The JSON string corresponding to the list of comments.
-  */
+   * Converts a list of strings to a JSON string.
+   *
+   * <p>
+   *
+   * @param comments The List of String comments that should be converted to a JSON string.
+   * @return <code>String</code> The JSON string corresponding to the list of comments.
+   */
   private String convertToJson(List<String> comments) {
     Gson gson = new Gson();
     String json = gson.toJson(comments);

--- a/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
@@ -17,7 +17,6 @@ package com.google.sps.servlets;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
-import com.google.gson.Gson;
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -28,18 +27,18 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/new-comment")
 public class NewCommentServlet extends HttpServlet {
   private static DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-  
+
   /**
-  * This Method handles POST requests corresponding to a new comment and creates a new Entity
-  * for that comment in the Google Cloud Datastore.
-  * <p>
-  * The POST request also results in a re-direct back to the original server-dev page.
-  * TODO(Issue #15): Do verfification on a new comment before adding it to the comments list.
-  *
-  * @param  request  The <code>HttpServletRequest</code> for the POST request.
-  * @param  response The <code>HttpServletResponse</code> for the POST request.
-  * @return None. A Entity of the Comment kind is created and upserted to the Datastore.
-  */
+   * This Method handles POST requests corresponding to a new comment and creates a new Entity for
+   * that comment in the Google Cloud Datastore.
+   *
+   * <p>The POST request also results in a re-direct back to the original server-dev page.
+   * TODO(Issue #15): Do verfification on a new comment before adding it to the comments list.
+   *
+   * @param request The <code>HttpServletRequest</code> for the POST request.
+   * @param response The <code>HttpServletResponse</code> for the POST request.
+   * @return None. A Entity of the Comment kind is created and upserted to the Datastore.
+   */
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String newComment = request.getParameter("comment");

--- a/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
@@ -29,15 +29,13 @@ public class NewCommentServlet extends HttpServlet {
   private static DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
   /**
-   * This Method handles POST requests corresponding to a new comment and creates a new Entity for
-   * that comment in the Google Cloud Datastore.
+   * {@inheritDoc}
+   * 
+   * <p>This Method handles POST requests corresponding to a new comment and creates a new Entity 
+   * for that comment in the Google Cloud Datastore.
    *
    * <p>The POST request also results in a re-direct back to the original server-dev page.
    * TODO(Issue #15): Do verfification on a new comment before adding it to the comments list.
-   *
-   * @param request The <code>HttpServletRequest</code> for the POST request.
-   * @param response The <code>HttpServletResponse</code> for the POST request.
-   * @return None. A Entity of the Comment kind is created and upserted to the Datastore.
    */
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/portfolio/src/main/webapp/pages/server-dev.html
+++ b/portfolio/src/main/webapp/pages/server-dev.html
@@ -56,11 +56,11 @@
         </section>
         <section class="content">
           <h2>Comments Thread</h2>
-          <div>
+          <form method="GET">
             <label for="num-comments">Number of comments to display (0 - 100): </label>
-            <input type="number" id="num-comments" min="0" max="100" value="0">
+            <input type="number" id="num-comments" name="num-comments" value="5" min="0" max="100">
             <button onclick="getCommentsThread()">Submit</button>
-          </div>
+          </form>
           <ul id="comments-thread"></ul>
         </section>
       </main>

--- a/portfolio/src/main/webapp/pages/server-dev.html
+++ b/portfolio/src/main/webapp/pages/server-dev.html
@@ -56,6 +56,11 @@
         </section>
         <section class="content">
           <h2>Comments Thread</h2>
+          <div>
+            <label for="num-comments">Number of comments to display (0 - 100): </label>
+            <input type="number" id="num-comments" min="0" max="100" value="0">
+            <button onclick="getCommentsThread()">Submit</button>
+          </div>
           <ul id="comments-thread"></ul>
         </section>
       </main>

--- a/portfolio/src/main/webapp/scripts/server-dev.js
+++ b/portfolio/src/main/webapp/scripts/server-dev.js
@@ -63,18 +63,18 @@ function getNumCommentstoDisplay(numComments) {
   const urlParams = new URLSearchParams(window.location.search);
   let newNumCommentsToDisplay = urlParams.get('num-comments');
   const currNumCommentsToDisplay = parseInt(
-      sessionStorage.getItem('numCommentsCached'));
+      sessionStorage.getItem('currNumCommentsToDisplay'));
 
   if (newNumCommentsToDisplay == null) {
     if (isNaN(currNumCommentsToDisplay)) {
       const defaultNumComments = document.getElementById('num-comments').value;
       newNumCommentsToDisplay = defaultNumComments;
-      sessionStorage.setItem('numCommentsCached', defaultNumComments);   
+      sessionStorage.setItem('currNumCommentsToDisplay', defaultNumComments);   
     } else {
       newNumCommentsToDisplay = currNumCommentsToDisplay;
     }
   } else {
-    sessionStorage.setItem('numCommentsCached', newNumCommentsToDisplay);
+    sessionStorage.setItem('currNumCommentsToDisplay', newNumCommentsToDisplay);
   }
   return Math.min(newNumCommentsToDisplay, numComments);
 }

--- a/portfolio/src/main/webapp/scripts/server-dev.js
+++ b/portfolio/src/main/webapp/scripts/server-dev.js
@@ -32,8 +32,8 @@ function getCommentsThread() {
         const commentThread = document.getElementById('comments-thread');
         const urlParams = new URLSearchParams(window.location.search);
 
-        // Determine the number of comments to display
-        var numComments = urlParams.get('num-comments');
+        // Determine the number of comments to display.
+        let numComments = urlParams.get('num-comments');
         const numCommentsStored = parseInt(
             sessionStorage.getItem("numComments"));
         if (numComments == null) {
@@ -44,7 +44,7 @@ function getCommentsThread() {
         const maxCommentIdx = Math.min(numComments, commentList.length);
 
         document.getElementById('comments-thread').innerHTML = "";
-        for (var cmntIdx = 0; cmntIdx < maxCommentIdx; cmntIdx++) {
+        for (let cmntIdx = 0; cmntIdx < maxCommentIdx; cmntIdx++) {
           commentThread.appendChild(createListElement(commentList[cmntIdx]));
         }
       })

--- a/portfolio/src/main/webapp/scripts/server-dev.js
+++ b/portfolio/src/main/webapp/scripts/server-dev.js
@@ -66,7 +66,13 @@ function getNumCommentstoDisplay(numCommentsDatabase) {
       sessionStorage.getItem('numCommentsCached'));
       
   if (numCommentsSelected == null) {
-    numCommentsSelected = numCommentsCached;
+    if (isNaN(numCommentsCached)) {
+      const defaultNumComments = document.getElementById('num-comments').value;
+      numCommentsSelected = defaultNumComments;
+      sessionStorage.setItem('numCommentsCached', defaultNumComments);   
+    } else {
+      numCommentsSelected = numCommentsCached;
+    }
   } else {
     sessionStorage.setItem('numCommentsCached', numCommentsSelected);
   }

--- a/portfolio/src/main/webapp/scripts/server-dev.js
+++ b/portfolio/src/main/webapp/scripts/server-dev.js
@@ -15,23 +15,34 @@
 /**
  * Fetches the previously entered comments from the server and inserts each
  * comment as a list item of the 'comments' <ul> element.
+ *
+ * <p>
+ *
+ * An option to determine the maximum number of comments is also included
+ * using a Query String parameter created from the num-comments form. When
+ * the page is (re-)loaded, the number of comments displayed is determined
+ * from the selection in the previous session. Otherwise, the last  most
+ * recently submitted number selection will be used. The number of comments
+ * will also never exceed the number of total comments returned from the
+ * datastore.
  */
 function getCommentsThread() {
   fetch('/comment-data')
       .then(response => response.json())
       .then((commentList) => {
         const commentThread = document.getElementById('comments-thread');
+        const urlParams = new URLSearchParams(window.location.search);
 
-        const numCommentsToDispStored = parseInt(sessionStorage.getItem("numCommentsToDisp"));
-        console.log(numCommentsToDispStored)
-        var numCommentsToDisp = document.getElementById("num-comments").value;
-        if (numCommentsToDisp != numCommentsToDispStored) {
-          numCommentsToDisp = numCommentsToDispNew;
+        // Determine the number of comments to display
+        var numComments = urlParams.get('num-comments');
+        const numCommentsStored = parseInt(
+            sessionStorage.getItem("numComments"));
+        if (numComments == null) {
+          numComments = numCommentsStored;
+        } else {
+          sessionStorage.setItem("numComments", numComments);
         }
-        sessionStorage.setItem("numCommentsToDisp", numCommentsToDisp);
-        console.log(numCommentsToDisp)
-        console.log('-------')
-        const maxCommentIdx = Math.min(numCommentsToDisp, commentList.length);
+        const maxCommentIdx = Math.min(numComments, commentList.length);
 
         document.getElementById('comments-thread').innerHTML = "";
         for (var cmntIdx = 0; cmntIdx < maxCommentIdx; cmntIdx++) {
@@ -48,6 +59,7 @@ function getCommentsThread() {
 
 /**
  * Creates an <li> element containing 'text'. 
+ * 
  * @param {string} text the inner text of the created <li> element.
  * @return {li} The list element created.
  */

--- a/portfolio/src/main/webapp/scripts/server-dev.js
+++ b/portfolio/src/main/webapp/scripts/server-dev.js
@@ -15,9 +15,7 @@
 /**
  * Fetches the previously entered comments from the server and inserts each
  * comment as a list item of the 'comments' <ul> element.
- *
- * <p>
- *
+ * 
  * An option to determine the maximum number of comments is also included
  * using a Query String parameter created from the num-comments form. When
  * the page is (re-)loaded, the number of comments displayed is determined
@@ -60,7 +58,7 @@ function getCommentsThread() {
  * Creates an <li> element containing 'text'. 
  * 
  * @param {string} text the inner text of the created <li> element.
- * @return {li} The list element created.
+ * @return {HTMLLIElement} The list element created.
  */
 function createListElement(text) {
   const liElement = document.createElement('li');

--- a/portfolio/src/main/webapp/scripts/server-dev.js
+++ b/portfolio/src/main/webapp/scripts/server-dev.js
@@ -24,11 +24,12 @@ function getCommentsThread() {
       .then(response => response.json())
       .then((commentsList) => {
         numComments = getNumCommentstoDisplay(commentsList.length);
+        document.getElementById('num-comments').value = numComments;
 
         const commentsThread = document.getElementById('comments-thread');
         document.getElementById('comments-thread').innerHTML = "";
         for (let cmntIdx = 0; cmntIdx < numComments; cmntIdx++) {
-          commentThread.appendChild(createListElement(commentsList[cmntIdx]));
+          commentsThread.appendChild(createListElement(commentsList[cmntIdx]));
         }
       })
       .catch(err => {
@@ -62,12 +63,12 @@ function getNumCommentstoDisplay(numCommentsDatabase) {
   const urlParams = new URLSearchParams(window.location.search);
   let numCommentsSelected = urlParams.get('num-comments');
   const numCommentsCached = parseInt(
-      sessionStorage.getItem("numCommentsCached"));
+      sessionStorage.getItem('numCommentsCached'));
       
   if (numCommentsSelected == null) {
     numCommentsSelected = numCommentsCached;
   } else {
-    sessionStorage.setItem("numCommentsCached", numCommentsSelected);
+    sessionStorage.setItem('numCommentsCached', numCommentsSelected);
   }
   return Math.min(numCommentsSelected, numCommentsDatabase);
 }

--- a/portfolio/src/main/webapp/scripts/server-dev.js
+++ b/portfolio/src/main/webapp/scripts/server-dev.js
@@ -21,10 +21,9 @@
  * An option to determine the maximum number of comments is also included
  * using a Query String parameter created from the num-comments form. When
  * the page is (re-)loaded, the number of comments displayed is determined
- * from the selection in the previous session. Otherwise, the last  most
- * recently submitted number selection will be used. The number of comments
- * will also never exceed the number of total comments returned from the
- * datastore.
+ * from the selection in the previous session. Otherwise, the most recently
+ * submitted number selection will be used. The number of comments will
+ * also never exceed the number of total comments returned from the datastore.
  */
 function getCommentsThread() {
   fetch('/comment-data')

--- a/portfolio/src/main/webapp/scripts/server-dev.js
+++ b/portfolio/src/main/webapp/scripts/server-dev.js
@@ -27,7 +27,7 @@ function getCommentsThread() {
         document.getElementById('num-comments').value = numComments;
 
         const commentsThread = document.getElementById('comments-thread');
-        document.getElementById('comments-thread').innerHTML = "";
+        commentsThread.innerHTML = "";
         for (let cmntIdx = 0; cmntIdx < numComments; cmntIdx++) {
           commentsThread.appendChild(createListElement(commentsList[cmntIdx]));
         }

--- a/portfolio/src/main/webapp/scripts/server-dev.js
+++ b/portfolio/src/main/webapp/scripts/server-dev.js
@@ -54,29 +54,29 @@ function getCommentsThread() {
  * used. The number of comments will also never exceed the number of total
  * comments returned from the datastore.
  * 
- * @param {number} numCommentsDatabase The number of comments stored in the 
- *    Cloud Datastore.
+ * @param {number} numComments The number of comments stored in the Cloud 
+ *    Datastore.
  * @return {number} The number of comments to be displayed in the comments 
  *    thread.
  */
-function getNumCommentstoDisplay(numCommentsDatabase) {
+function getNumCommentstoDisplay(numComments) {
   const urlParams = new URLSearchParams(window.location.search);
-  let numCommentsSelected = urlParams.get('num-comments');
-  const numCommentsCached = parseInt(
+  let newNumCommentsToDisplay = urlParams.get('num-comments');
+  const currNumCommentsToDisplay = parseInt(
       sessionStorage.getItem('numCommentsCached'));
-      
-  if (numCommentsSelected == null) {
-    if (isNaN(numCommentsCached)) {
+
+  if (newNumCommentsToDisplay == null) {
+    if (isNaN(currNumCommentsToDisplay)) {
       const defaultNumComments = document.getElementById('num-comments').value;
-      numCommentsSelected = defaultNumComments;
+      newNumCommentsToDisplay = defaultNumComments;
       sessionStorage.setItem('numCommentsCached', defaultNumComments);   
     } else {
-      numCommentsSelected = numCommentsCached;
+      newNumCommentsToDisplay = currNumCommentsToDisplay;
     }
   } else {
-    sessionStorage.setItem('numCommentsCached', numCommentsSelected);
+    sessionStorage.setItem('numCommentsCached', newNumCommentsToDisplay);
   }
-  return Math.min(numCommentsSelected, numCommentsDatabase);
+  return Math.min(newNumCommentsToDisplay, numComments);
 }
 
 /**

--- a/portfolio/src/main/webapp/scripts/server-dev.js
+++ b/portfolio/src/main/webapp/scripts/server-dev.js
@@ -16,34 +16,19 @@
  * Fetches the previously entered comments from the server and inserts each
  * comment as a list item of the 'comments' <ul> element.
  * 
- * An option to determine the maximum number of comments is also included
- * using a Query String parameter created from the num-comments form. When
- * the page is (re-)loaded, the number of comments displayed is determined
- * from the selection in the previous session. Otherwise, the most recently
- * submitted number selection will be used. The number of comments will
- * also never exceed the number of total comments returned from the datastore.
+ * The number of comments displayed is determined by 
+ * getNumCommentstoDisplay().
  */
 function getCommentsThread() {
   fetch('/comment-data')
       .then(response => response.json())
-      .then((commentList) => {
-        const commentThread = document.getElementById('comments-thread');
-        const urlParams = new URLSearchParams(window.location.search);
+      .then((commentsList) => {
+        numComments = getNumCommentstoDisplay(commentsList.length);
 
-        // Determine the number of comments to display.
-        let numComments = urlParams.get('num-comments');
-        const numCommentsStored = parseInt(
-            sessionStorage.getItem("numComments"));
-        if (numComments == null) {
-          numComments = numCommentsStored;
-        } else {
-          sessionStorage.setItem("numComments", numComments);
-        }
-        const maxCommentIdx = Math.min(numComments, commentList.length);
-
+        const commentsThread = document.getElementById('comments-thread');
         document.getElementById('comments-thread').innerHTML = "";
-        for (let cmntIdx = 0; cmntIdx < maxCommentIdx; cmntIdx++) {
-          commentThread.appendChild(createListElement(commentList[cmntIdx]));
+        for (let cmntIdx = 0; cmntIdx < numComments; cmntIdx++) {
+          commentThread.appendChild(createListElement(commentsList[cmntIdx]));
         }
       })
       .catch(err => {
@@ -55,9 +40,42 @@ function getCommentsThread() {
 }
 
 /**
+ * Determines the number of comments that should be displayed in the comments
+ * thread based on the the current user selection, the last user selection 
+ * cached in the session, and the total number of comments stored in the 
+ * database.
+ * 
+ * An option to determine the maximum number of comments is implemented
+ * using a Query String parameter created from the num-comments form. When
+ * the page is (re-)loaded, the number of comments displayed is determined
+ * using the cached value corresponding to the selection in the previous 
+ * session. Otherwise, the most recently submitted number selection will be
+ * used. The number of comments will also never exceed the number of total
+ * comments returned from the datastore.
+ * 
+ * @param {number} numCommentsDatabase The number of comments stored in the 
+ *    Cloud Datastore.
+ * @return {number} The number of comments to be displayed in the comments 
+ *    thread.
+ */
+function getNumCommentstoDisplay(numCommentsDatabase) {
+  const urlParams = new URLSearchParams(window.location.search);
+  let numCommentsSelected = urlParams.get('num-comments');
+  const numCommentsCached = parseInt(
+      sessionStorage.getItem("numCommentsCached"));
+      
+  if (numCommentsSelected == null) {
+    numCommentsSelected = numCommentsCached;
+  } else {
+    sessionStorage.setItem("numCommentsCached", numCommentsSelected);
+  }
+  return Math.min(numCommentsSelected, numCommentsDatabase);
+}
+
+/**
  * Creates an <li> element containing 'text'. 
  * 
- * @param {string} text the inner text of the created <li> element.
+ * @param {string} text The inner text of the created <li> element.
  * @return {HTMLLIElement} The list element created.
  */
 function createListElement(text) {

--- a/portfolio/src/main/webapp/scripts/server-dev.js
+++ b/portfolio/src/main/webapp/scripts/server-dev.js
@@ -21,9 +21,22 @@ function getCommentsThread() {
       .then(response => response.json())
       .then((commentList) => {
         const commentThread = document.getElementById('comments-thread');
-        commentList.forEach((comment) => {
-          commentThread.appendChild(createListElement(comment));
-        });
+
+        const numCommentsToDispStored = parseInt(sessionStorage.getItem("numCommentsToDisp"));
+        console.log(numCommentsToDispStored)
+        var numCommentsToDisp = document.getElementById("num-comments").value;
+        if (numCommentsToDisp != numCommentsToDispStored) {
+          numCommentsToDisp = numCommentsToDispNew;
+        }
+        sessionStorage.setItem("numCommentsToDisp", numCommentsToDisp);
+        console.log(numCommentsToDisp)
+        console.log('-------')
+        const maxCommentIdx = Math.min(numCommentsToDisp, commentList.length);
+
+        document.getElementById('comments-thread').innerHTML = "";
+        for (var cmntIdx = 0; cmntIdx < maxCommentIdx; cmntIdx++) {
+          commentThread.appendChild(createListElement(commentList[cmntIdx]));
+        }
       })
       .catch(err => {
         console.log('Error: ' + err);


### PR DESCRIPTION
The feature added in this PR is an option to determine the maximum number of comments is also included using a Query String parameter created from the num-comments form. When the page is (re-)loaded, the number of comments displayed is determined from the selection in the previous session. Otherwise, the most recently submitted number selection will be used. The number of comments will also never exceed the number of total comments returned from the datastore.
