### PR TITLE
Step 6: Delete Comments

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteCommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteCommentsServlet.java
@@ -16,6 +16,7 @@ package com.google.sps.servlets;
 
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
@@ -46,7 +47,9 @@ public class DeleteCommentsServlet extends HttpServlet {
     PreparedQuery results = datastore.prepare(query);
 
     List<Key> entityKeys = new ArrayList<>();
-    results.forEach(entityKeys::add);
+    for (Entity commentEntity : results.asIterable()) {
+      entityKeys.add(commentEntity.getKey());
+    }
     datastore.delete(entityKeys);
 
     response.sendRedirect("/pages/server-dev.html");

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteCommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteCommentsServlet.java
@@ -47,9 +47,7 @@ public class DeleteCommentsServlet extends HttpServlet {
     PreparedQuery results = datastore.prepare(query);
 
     List<Key> entityKeys = new ArrayList<>();
-    for (Entity commentEntity : results.asIterable()) {
-      entityKeys.add(commentEntity.getKey());
-    }
+    results.forEach(entityKeys::add);
     for (Key key : entityKeys) {
       datastore.delete(key);
     }

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteCommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteCommentsServlet.java
@@ -1,0 +1,59 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.getKey;
+import com.google.appengine.api.datastore.Key;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** Servlet that enters new comments into the Datastore. */
+@WebServlet("/delete-comments")
+public class DeleteCommentsServlet extends HttpServlet {
+  private static DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
+  /**
+   * This Method handles POST requests corresponding to a new comment and creates a new Entity for
+   * that comment in the Google Cloud Datastore.
+   *
+   * <p>The POST request also results in a re-direct back to the original server-dev page.
+   * TODO(Issue #15): Do verfification on a new comment before adding it to the comments list.
+   *
+   * @param request The <code>HttpServletRequest</code> for the POST request.
+   * @param response The <code>HttpServletResponse</code> for the POST request.
+   * @return None. A Entity of the Comment kind is created and upserted to the Datastore.
+   */
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    Query query = new Query("Comment");
+    PreparedQuery results = datastore.prepare(query);
+
+    List<Key> entityKeys = new ArrayList();
+    for (Entity commentEntity : results.asIterable()) {
+      entityKeys.append(commentEntity.getKey())
+    }
+    for (Key key : entityKeys) {
+      datastore.delete(key)
+    }
+
+    response.sendRedirect("/pages/server-dev.html");
+  }
+}

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteCommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteCommentsServlet.java
@@ -25,21 +25,22 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/** Servlet that enters new comments into the Datastore. */
+/** Servlet that deletes all comments from the Datastore. */
 @WebServlet("/delete-comments")
 public class DeleteCommentsServlet extends HttpServlet {
   private static DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
   /**
-   * This Method handles POST requests corresponding to a new comment and creates a new Entity for
-   * that comment in the Google Cloud Datastore.
+   * This Method handles POST requests corresponding to deleting all Comment kind Entities from
+   * the Google Cloud Datastore.
    *
-   * <p>The POST request also results in a re-direct back to the original server-dev page.
-   * TODO(Issue #15): Do verfification on a new comment before adding it to the comments list.
+   * <p>
+   * 
+   * The POST request also results in a re-direct back to the original server-dev page.
    *
    * @param request The <code>HttpServletRequest</code> for the POST request.
    * @param response The <code>HttpServletResponse</code> for the POST request.
-   * @return None. A Entity of the Comment kind is created and upserted to the Datastore.
+   * @return None. All entities in the 'Comments' kind are deleted.
    */
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteCommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteCommentsServlet.java
@@ -16,7 +16,6 @@ package com.google.sps.servlets;
 
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
-import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
@@ -35,9 +34,9 @@ public class DeleteCommentsServlet extends HttpServlet {
 
   /**
    * {@inheritDoc}
-   * 
-   * <p>This Method handles POST requests corresponding to deleting all Comment kind Entities from the
-   * Google Cloud Datastore.
+   *
+   * <p>This Method handles POST requests corresponding to deleting all Comment kind Entities from
+   * the Google Cloud Datastore.
    *
    * <p>The POST request also results in a re-direct back to the original server-dev page.
    */
@@ -48,9 +47,7 @@ public class DeleteCommentsServlet extends HttpServlet {
 
     List<Key> entityKeys = new ArrayList<>();
     results.forEach(entityKeys::add);
-    for (Key key : entityKeys) {
-      datastore.delete(key);
-    }
+    datastore.delete(entityKeys);
 
     response.sendRedirect("/pages/server-dev.html");
   }

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteCommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteCommentsServlet.java
@@ -17,9 +17,13 @@ package com.google.sps.servlets;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.getKey;
 import com.google.appengine.api.datastore.Key;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -49,10 +53,10 @@ public class DeleteCommentsServlet extends HttpServlet {
 
     List<Key> entityKeys = new ArrayList();
     for (Entity commentEntity : results.asIterable()) {
-      entityKeys.append(commentEntity.getKey())
+      entityKeys.append(commentEntity.getKey());
     }
     for (Key key : entityKeys) {
-      datastore.delete(key)
+      datastore.delete(key);
     }
 
     response.sendRedirect("/pages/server-dev.html");

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteCommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteCommentsServlet.java
@@ -34,14 +34,12 @@ public class DeleteCommentsServlet extends HttpServlet {
   private static DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
   /**
-   * This Method handles POST requests corresponding to deleting all Comment kind Entities from the
+   * {@inheritDoc}
+   * 
+   * <p>This Method handles POST requests corresponding to deleting all Comment kind Entities from the
    * Google Cloud Datastore.
    *
    * <p>The POST request also results in a re-direct back to the original server-dev page.
-   *
-   * @param request The <code>HttpServletRequest</code> for the POST request.
-   * @param response The <code>HttpServletResponse</code> for the POST request.
-   * @return None. All entities in the 'Comments' kind are deleted.
    */
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteCommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteCommentsServlet.java
@@ -17,10 +17,9 @@ package com.google.sps.servlets;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
-import com.google.appengine.api.datastore.getKey;
-import com.google.appengine.api.datastore.Key;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -35,12 +34,10 @@ public class DeleteCommentsServlet extends HttpServlet {
   private static DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
   /**
-   * This Method handles POST requests corresponding to deleting all Comment kind Entities from
-   * the Google Cloud Datastore.
+   * This Method handles POST requests corresponding to deleting all Comment kind Entities from the
+   * Google Cloud Datastore.
    *
-   * <p>
-   * 
-   * The POST request also results in a re-direct back to the original server-dev page.
+   * <p>The POST request also results in a re-direct back to the original server-dev page.
    *
    * @param request The <code>HttpServletRequest</code> for the POST request.
    * @param response The <code>HttpServletResponse</code> for the POST request.
@@ -51,9 +48,9 @@ public class DeleteCommentsServlet extends HttpServlet {
     Query query = new Query("Comment");
     PreparedQuery results = datastore.prepare(query);
 
-    List<Key> entityKeys = new ArrayList();
+    List<Key> entityKeys = new ArrayList<>();
     for (Entity commentEntity : results.asIterable()) {
-      entityKeys.append(commentEntity.getKey());
+      entityKeys.add(commentEntity.getKey());
     }
     for (Key key : entityKeys) {
       datastore.delete(key);

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentsServlet.java
@@ -36,9 +36,9 @@ public class ListCommentsServlet extends HttpServlet {
 
   /**
    * {@inheritDoc}
-   * 
-   * <p>This Method handles GET requests in order to display all of the comments that are stored in the
-   * Comments kind of the Google Cloud Datastore.
+   *
+   * <p>This Method handles GET requests in order to display all of the comments that are stored in
+   * the Comments kind of the Google Cloud Datastore.
    */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -55,7 +55,6 @@ public class ListCommentsServlet extends HttpServlet {
     response.setContentType("application/json;");
     response.getWriter().println(jsonComments);
   }
-
 
   /**
    * Converts a list of strings to a JSON string.

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentsServlet.java
@@ -35,13 +35,10 @@ public class ListCommentsServlet extends HttpServlet {
   private static DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
   /**
-   * This Method handles GET requests in order to display all of the comments that are stored in the
+   * {@inheritDoc}
+   * 
+   * <p>This Method handles GET requests in order to display all of the comments that are stored in the
    * Comments kind of the Google Cloud Datastore.
-   *
-   * @param request The <code>HttpServletRequest</code> for the GET request.
-   * @param response The <code>HttpServletResponse</code> for the GET request.
-   * @return None. The Servlet writes to the /comment-data page which JavaScript then fetches in
-   *     order to serve the comments to the UI.
    */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -58,6 +55,7 @@ public class ListCommentsServlet extends HttpServlet {
     response.setContentType("application/json;");
     response.getWriter().println(jsonComments);
   }
+
 
   /**
    * Converts a list of strings to a JSON string.

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentsServlet.java
@@ -38,8 +38,6 @@ public class ListCommentsServlet extends HttpServlet {
    * This Method handles GET requests in order to display all of the comments that are stored in the
    * Comments kind of the Google Cloud Datastore.
    *
-   * <p>
-   *
    * @param request The <code>HttpServletRequest</code> for the GET request.
    * @param response The <code>HttpServletResponse</code> for the GET request.
    * @return None. The Servlet writes to the /comment-data page which JavaScript then fetches in
@@ -63,8 +61,6 @@ public class ListCommentsServlet extends HttpServlet {
 
   /**
    * Converts a list of strings to a JSON string.
-   *
-   * <p>
    *
    * @param comments The List of String comments that should be converted to a JSON string.
    * @return <code>String</code> The JSON string corresponding to the list of comments.

--- a/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
@@ -29,15 +29,13 @@ public class NewCommentServlet extends HttpServlet {
   private static DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
   /**
-   * This Method handles POST requests corresponding to a new comment and creates a new Entity for
-   * that comment in the Google Cloud Datastore.
+   * {@inheritDoc}
+   * 
+   * <p>This Method handles POST requests corresponding to a new comment and creates a new Entity 
+   * for that comment in the Google Cloud Datastore.
    *
    * <p>The POST request also results in a re-direct back to the original server-dev page.
    * TODO(Issue #15): Do verfification on a new comment before adding it to the comments list.
-   *
-   * @param request The <code>HttpServletRequest</code> for the POST request.
-   * @param response The <code>HttpServletResponse</code> for the POST request.
-   * @return None. A Entity of the Comment kind is created and upserted to the Datastore.
    */
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/portfolio/src/main/webapp/pages/server-dev.html
+++ b/portfolio/src/main/webapp/pages/server-dev.html
@@ -62,8 +62,8 @@
             <button onclick="getCommentsThread()">Submit</button>
           </form>
           <ul id="comments-thread"></ul><br/>
-          <form action="/delete-comments">
-            <input type="submit" />
+          <form action="/delete-comments" method="POST">
+            <button type="submit">Delete Comments</button>
           </form>
         </section>
       </main>

--- a/portfolio/src/main/webapp/pages/server-dev.html
+++ b/portfolio/src/main/webapp/pages/server-dev.html
@@ -61,7 +61,10 @@
             <input type="number" id="num-comments" name="num-comments" value="5" min="0" max="100">
             <button onclick="getCommentsThread()">Submit</button>
           </form>
-          <ul id="comments-thread"></ul>
+          <ul id="comments-thread"></ul><br/>
+          <form action="/delete-comments">
+            <input type="submit" />
+          </form>
         </section>
       </main>
     </div>

--- a/portfolio/src/main/webapp/scripts/home.js
+++ b/portfolio/src/main/webapp/scripts/home.js
@@ -12,6 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-function reload(){
-  window.open("/index.html","_self");
+function reload() {
+  window.open('/index.html', '_self');
 }

--- a/portfolio/src/main/webapp/scripts/server-dev.js
+++ b/portfolio/src/main/webapp/scripts/server-dev.js
@@ -16,36 +16,21 @@
 /**
  * Fetches the previously entered comments from the server and inserts each
  * comment as a list item of the 'comments' <ul> element.
- *
- * An option to determine the maximum number of comments is also included
- * using a Query String parameter created from the num-comments form. When
- * the page is (re-)loaded, the number of comments displayed is determined
- * from the selection in the previous session. Otherwise, the most recently
- * submitted number selection will be used. The number of comments will
- * also never exceed the number of total comments returned from the datastore.
+ * 
+ * The number of comments displayed is determined by 
+ * getNumCommentstoDisplay().
  */
 function getCommentsThread() {
   fetch('/comment-data')
       .then(response => response.json())
-      .then((commentList) => {
-        const commentThread = document.getElementById('comments-thread');
-        const urlParams = new URLSearchParams(window.location.search);
-
-        // Determine the number of comments to display.
-        let numComments = urlParams.get('num-comments');
-        const numCommentsStored = parseInt(
-            sessionStorage.getItem('numComments'));
-        if (numComments == null) {
-          numComments = numCommentsStored;
-        } else {
-          sessionStorage.setItem('numComments', numComments);
-        }
-        const maxCommentIdx = Math.min(numComments, commentList.length);
+      .then((commentsList) => {
+        numComments = getNumCommentstoDisplay(commentsList.length);
         document.getElementById('num-comments').value = numComments;
 
-        document.getElementById('comments-thread').innerHTML = '';
-        for (let cmntIdx = 0; cmntIdx < maxCommentIdx; cmntIdx++) {
-          commentThread.appendChild(createListElement(commentList[cmntIdx]));
+        const commentsThread = document.getElementById('comments-thread');
+        commentsThread.innerHTML = '';
+        for (let cmntIdx = 0; cmntIdx < numComments; cmntIdx++) {
+          commentsThread.appendChild(createListElement(commentsList[cmntIdx]));
         }
       })
       .catch(err => {
@@ -54,6 +39,45 @@ function getCommentsThread() {
         appendChild(createListElement('Error: Unable to load ' +
                                       'the comments thread.'));
       });
+}
+
+/**
+ * Determines the number of comments that should be displayed in the comments
+ * thread based on the the current user selection, the last user selection 
+ * cached in the session, and the total number of comments stored in the 
+ * database.
+ * 
+ * An option to determine the maximum number of comments is implemented
+ * using a Query String parameter created from the num-comments form. When
+ * the page is (re-)loaded, the number of comments displayed is determined
+ * using the cached value corresponding to the selection in the previous 
+ * session. Otherwise, the most recently submitted number selection will be
+ * used. The number of comments will also never exceed the number of total
+ * comments returned from the datastore.
+ * 
+ * @param {number} numComments The number of comments stored in the Cloud 
+ *    Datastore.
+ * @return {number} The number of comments to be displayed in the comments 
+ *    thread.
+ */
+function getNumCommentstoDisplay(numComments) {
+  const urlParams = new URLSearchParams(window.location.search);
+  let newNumCommentsToDisplay = urlParams.get('num-comments');
+  const currNumCommentsToDisplay = parseInt(
+      sessionStorage.getItem('currNumCommentsToDisplay'));
+
+  if (newNumCommentsToDisplay == null) {
+    if (isNaN(currNumCommentsToDisplay)) {
+      const defaultNumComments = document.getElementById('num-comments').value;
+      newNumCommentsToDisplay = defaultNumComments;
+      sessionStorage.setItem('currNumCommentsToDisplay', defaultNumComments);   
+    } else {
+      newNumCommentsToDisplay = currNumCommentsToDisplay;
+    }
+  } else {
+    sessionStorage.setItem('currNumCommentsToDisplay', newNumCommentsToDisplay);
+  }
+  return Math.min(newNumCommentsToDisplay, numComments);
 }
 
 /**

--- a/portfolio/src/main/webapp/scripts/server-dev.js
+++ b/portfolio/src/main/webapp/scripts/server-dev.js
@@ -35,7 +35,7 @@ function getCommentsThread() {
 
         var numComments = urlParams.get('num-comments');
         const numCommentsStored = parseInt(
-           sessionStorage.getItem('numComments'));
+            sessionStorage.getItem('numComments'));
         if (numComments == null) {
           numComments = numCommentsStored;
         } else {
@@ -49,12 +49,12 @@ function getCommentsThread() {
           commentThread.appendChild(createListElement(commentList[cmntIdx]));
         }
       })
-    .catch(err => {
-      console.log('Error: ' + err);
-      document.getElementById('comments-thread').
-      appendChild(createListElement('Error: Unable to load ' +
-                                    'the comments thread.'));
-    });
+      .catch(err => {
+        console.log('Error: ' + err);
+        document.getElementById('comments-thread').
+        appendChild(createListElement('Error: Unable to load ' +
+                                      'the comments thread.'));
+      });
 }
 
 /**

--- a/portfolio/src/main/webapp/scripts/server-dev.js
+++ b/portfolio/src/main/webapp/scripts/server-dev.js
@@ -32,8 +32,8 @@ function getCommentsThread() {
         const commentThread = document.getElementById('comments-thread');
         const urlParams = new URLSearchParams(window.location.search);
 
-        // Determine the number of comments to display
-        var numComments = urlParams.get('num-comments');
+        // Determine the number of comments to display.
+        let numComments = urlParams.get('num-comments');
         const numCommentsStored = parseInt(
             sessionStorage.getItem("numComments"));
         if (numComments == null) {
@@ -45,7 +45,7 @@ function getCommentsThread() {
         document.getElementById('num-comments').value = numComments;
 
         document.getElementById('comments-thread').innerHTML = "";
-        for (var cmntIdx = 0; cmntIdx < maxCommentIdx; cmntIdx++) {
+        for (let cmntIdx = 0; cmntIdx < maxCommentIdx; cmntIdx++) {
           commentThread.appendChild(createListElement(commentList[cmntIdx]));
         }
       })

--- a/portfolio/src/main/webapp/scripts/server-dev.js
+++ b/portfolio/src/main/webapp/scripts/server-dev.js
@@ -42,6 +42,7 @@ function getCommentsThread() {
           sessionStorage.setItem("numComments", numComments);
         }
         const maxCommentIdx = Math.min(numComments, commentList.length);
+        document.getElementById('num-comments').value = numComments;
 
         document.getElementById('comments-thread').innerHTML = "";
         for (var cmntIdx = 0; cmntIdx < maxCommentIdx; cmntIdx++) {

--- a/portfolio/src/main/webapp/scripts/server-dev.js
+++ b/portfolio/src/main/webapp/scripts/server-dev.js
@@ -17,8 +17,6 @@
  * Fetches the previously entered comments from the server and inserts each
  * comment as a list item of the 'comments' <ul> element.
  *
- * <p>
- *
  * An option to determine the maximum number of comments is also included
  * using a Query String parameter created from the num-comments form. When
  * the page is (re-)loaded, the number of comments displayed is determined
@@ -62,7 +60,7 @@ function getCommentsThread() {
  * Creates an <li> element containing 'text'. 
  * 
  * @param {string} text the inner text of the created <li> element.
- * @return {li} The list element created.
+ * @return {HTMLLIElement} The list element created.
  */
 function createListElement(text) {
   const liElement = document.createElement('li');

--- a/portfolio/src/main/webapp/scripts/server-dev.js
+++ b/portfolio/src/main/webapp/scripts/server-dev.js
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+
 /**
  * Fetches the previously entered comments from the server and inserts each
  * comment as a list item of the 'comments' <ul> element.
@@ -32,29 +33,28 @@ function getCommentsThread() {
         const commentThread = document.getElementById('comments-thread');
         const urlParams = new URLSearchParams(window.location.search);
 
-        // Determine the number of comments to display
         var numComments = urlParams.get('num-comments');
         const numCommentsStored = parseInt(
-            sessionStorage.getItem("numComments"));
+           sessionStorage.getItem('numComments'));
         if (numComments == null) {
           numComments = numCommentsStored;
         } else {
-          sessionStorage.setItem("numComments", numComments);
+          sessionStorage.setItem('numComments', numComments);
         }
         const maxCommentIdx = Math.min(numComments, commentList.length);
         document.getElementById('num-comments').value = numComments;
 
-        document.getElementById('comments-thread').innerHTML = "";
+        document.getElementById('comments-thread').innerHTML = '';
         for (var cmntIdx = 0; cmntIdx < maxCommentIdx; cmntIdx++) {
           commentThread.appendChild(createListElement(commentList[cmntIdx]));
         }
       })
-      .catch(err => {
-        console.log('Error: ' + err);
-        document.getElementById('comments-thread').
-        appendChild(createListElement('Error: Unable to load ' +
-                                      'the comments thread.'));
-      });
+    .catch(err => {
+      console.log('Error: ' + err);
+      document.getElementById('comments-thread').
+      appendChild(createListElement('Error: Unable to load ' +
+                                    'the comments thread.'));
+    });
 }
 
 /**


### PR DESCRIPTION
This PR extends the changes from #16. The main feature added was one to delete all comments from the Google Cloud datastore. This included an additional button in the server-dev.html that sends a POST request to a new page (delete-comments). The servlet corresponding to this url gathers all of the keys for the Comments kind and subsequently deletes all of the corresponding Comment entities. The user is redirected to the server-dev page where there are no more comments visible.

In the future it may be wise to make sure that one user cannot delete everyone's comments. One good next step might be to add the Authentication API and allow users to only delete (and maybe edit) their comments. See issue #25.