### PR TITLE
Serve Blob Manually

### DIFF
--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -14,6 +14,8 @@
 
 package com.google.sps.data;
 
+import com.google.appengine.api.blobstore.BlobKey;
+
 /**
  * Class representing a comment created on server-dev.html.
  *
@@ -21,18 +23,19 @@ package com.google.sps.data;
  */
 public class Comment {
 
-  /** The strings of text for the comment */
+  /** The strings of text for the comment. */
   private final String text;
 
-  /** The image urls for the comment (null if no image for a comment) */
-  private final String imageUrl;
+  /** The keys corresponding to the image stored in the Blobstore for the
+      comment (null if no image for a comment). */
+  private final BlobKey blobKey;
 
   /** 
    * @param text The string of text for an individual comment.
-   * @param imageUrl The image URL for an individual comment (null if no image).
+   * @param blobKey The associated image blob key for an individual comment.
    */
-  public Comment(String text, String imageUrl) {
+  public Comment(String text, BlobKey blobKey) {
     this.text = text;
-    this.imageUrl = imageUrl; 
+    this.blobKey = blobKey; 
   }
 }

--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -23,19 +23,21 @@ import com.google.appengine.api.blobstore.BlobKey;
  */
 public class Comment {
 
-  /** The strings of text for the comment. */
+  /** The message content of the comment. */
   private final String text;
 
-  /** The keys corresponding to the image stored in the Blobstore for the
-      comment (null if no image for a comment). */
+  /**
+   * The keys corresponding to the image stored in the Blobstore for the comment 
+   * (null if no image for a comment).
+   */
   private final BlobKey blobKey;
 
-  /** 
+  /**
    * @param text The string of text for an individual comment.
    * @param blobKey The associated image blob key for an individual comment.
    */
   public Comment(String text, BlobKey blobKey) {
     this.text = text;
-    this.blobKey = blobKey; 
+    this.blobKey = blobKey;
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentsServlet.java
@@ -23,8 +23,8 @@ import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
-import com.google.sps.data.Comment;
 import com.google.gson.Gson;
+import com.google.sps.data.Comment;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -52,8 +52,10 @@ public class ListCommentsServlet extends HttpServlet {
 
     List<Comment> commentsThread = new ArrayList<>();
     for (Entity commentEntity : results.asIterable()) {
-      commentsThread.add(new Comment((String) commentEntity.getProperty("text"),
-                                     (BlobKey) commentEntity.getProperty("blobKey")));
+      commentsThread.add(
+          new Comment(
+              (String) commentEntity.getProperty("text"),
+              (BlobKey) commentEntity.getProperty("blobKey")));
     }
 
     String jsonComments = convertToJson(commentsThread);
@@ -65,7 +67,7 @@ public class ListCommentsServlet extends HttpServlet {
    * Converts a list of Comment objects to a JSON string.
    *
    * @param commentsThread The List of Comment objects that should be converted to a JSON string.
-   * @return               The JSON string corresponding to the list of comments.
+   * @return The JSON string corresponding to the list of comments.
    */
   private String convertToJson(List<Comment> commentsThread) {
     Gson gson = new Gson();

--- a/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
@@ -23,8 +23,6 @@ import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import javax.servlet.annotation.WebServlet;
@@ -46,9 +44,9 @@ public class NewCommentServlet extends HttpServlet {
    *
    * <p>This POST request originates from the 'new comment' form in server-dev.html and is initially
    * sent to Blobstore for file processing. Once the Blobstore forward the request to this servlet,
-   * the name of file submitted in the form can be used to get the corresponding blob key to be 
-   * stored in the Datastore
-   * Blobstore. The POST request also results in a re-direct back to the original server-dev page.
+   * the name of file submitted in the form can be used to get the corresponding blob key to be
+   * stored in the Datastore Blobstore. The POST request also results in a re-direct back to the
+   * original server-dev page.
    *
    * <p>TODO(Issue #15): Do verfification on a new comment before adding it to the comments list.
    */
@@ -72,8 +70,8 @@ public class NewCommentServlet extends HttpServlet {
    *
    * @param request The <code>HttpServletRequest</code> for the POST request.
    * @param formInputElementName The name attribute of the image file input to the form.
-   * @return The blob key associated with the uploaded image file. Null is returned if 
-   *         the user did not select a file or the file is not an image type.
+   * @return The blob key associated with the uploaded image file. Null is returned if the user did
+   *     not select a file or the file is not an image type.
    */
   private BlobKey getBlobKey(HttpServletRequest request, String formInputElementName) {
     Map<String, List<BlobKey>> blobs = blobstoreService.getUploads(request);

--- a/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
@@ -94,8 +94,8 @@ public class NewCommentServlet extends HttpServlet {
       return null;
     }
 
-    // Check the validity of the file here by making sure it's an image file
-    if (!"image".equals(blobInfo.getContentType().substring(0, 5))) {
+    // Ensure that uploaded file is an image file.
+    if (blobInfo.getContentType().startsWith("image") == false) {
       blobstoreService.delete(blobKey);
       return null;
     }

--- a/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
@@ -92,7 +92,7 @@ public class NewCommentServlet extends HttpServlet {
       return null;
     }
 
-    // Ensure that uploaded file is an image file.
+    // Non-image files are not supported.
     if (blobInfo.getContentType().startsWith("image") == false) {
       blobstoreService.delete(blobKey);
       return null;

--- a/portfolio/src/main/java/com/google/sps/servlets/ServeBlobs.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ServeBlobs.java
@@ -17,17 +17,7 @@ package com.google.sps.servlets;
 import com.google.appengine.api.blobstore.BlobKey;
 import com.google.appengine.api.blobstore.BlobstoreService;
 import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
-import com.google.appengine.api.datastore.DatastoreService;
-import com.google.appengine.api.datastore.DatastoreServiceFactory;
-import com.google.appengine.api.datastore.Entity;
-import com.google.appengine.api.datastore.PreparedQuery;
-import com.google.appengine.api.datastore.Query;
-import com.google.appengine.api.datastore.Query.SortDirection;
-import com.google.sps.data.Comment;
-import com.google.gson.Gson;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -41,8 +31,8 @@ public class ServeBlobs extends HttpServlet {
   /**
    * {@inheritDoc}
    *
-   * <p>This Method handles GET requests in order to serve files uploaded to Blobstore based on 
-   * the blob key placed in the URL query string. 
+   * <p>This Method handles GET requests in order to serve files uploaded to Blobstore based on the
+   * blob key placed in the URL query string.
    */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/portfolio/src/main/java/com/google/sps/servlets/ServeBlobs.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ServeBlobs.java
@@ -33,43 +33,20 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/** Servlet that returns comments stored in the Datastore. */
-@WebServlet("/comment-data")
-public class ListCommentsServlet extends HttpServlet {
-  private static DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+/** Servlet that returns (image) files stored in the Blobstore. */
+@WebServlet("/serve-image")
+public class ServeBlobs extends HttpServlet {
   private static BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
 
   /**
    * {@inheritDoc}
    *
-   * <p>This Method handles GET requests in order to display all of the comments that are stored in
-   * the Comments kind of the Google Cloud Datastore.
+   * <p>This Method handles GET requests in order to serve files uploaded to Blobstore based on 
+   * the blob key placed in the URL query string. 
    */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
-    PreparedQuery results = datastore.prepare(query);
-
-    List<Comment> commentsThread = new ArrayList<>();
-    for (Entity commentEntity : results.asIterable()) {
-      commentsThread.add(new Comment((String) commentEntity.getProperty("text"),
-                                     (BlobKey) commentEntity.getProperty("blobKey")));
-    }
-
-    String jsonComments = convertToJson(commentsThread);
-    response.setContentType("application/json;");
-    response.getWriter().println(jsonComments);
-  }
-
-  /**
-   * Converts a list of Comment objects to a JSON string.
-   *
-   * @param commentsThread The List of Comment objects that should be converted to a JSON string.
-   * @return               The JSON string corresponding to the list of comments.
-   */
-  private String convertToJson(List<Comment> commentsThread) {
-    Gson gson = new Gson();
-    String json = gson.toJson(commentsThread);
-    return json;
+    BlobKey blobKey = new BlobKey(request.getParameter("blob-key"));
+    blobstoreService.serve(blobKey, response);
   }
 }

--- a/portfolio/src/main/webapp/scripts/server-dev.js
+++ b/portfolio/src/main/webapp/scripts/server-dev.js
@@ -33,7 +33,7 @@ function getCommentsThread() {
         for (let cmntIdx = 0; cmntIdx < numCommentsToDisplay; cmntIdx++) {
           commentsThreadContainer.appendChild(createListElement(
                                           commentsThread[cmntIdx].text,
-                                          commentsThread[cmntIdx].imageUrl));
+                                          commentsThread[cmntIdx].blobKey));
         }
       })
       .catch(err => {
@@ -91,20 +91,20 @@ function getNumCommentstoDisplay(numComments) {
  * parent <li> element. 
  * 
  * @param {string} text the interior text of the created <li> element.
- * @param {?string} imageUrl the URL for the interior image of the created
- *    <li> element. If it is null, no image element is included in parent 
- *    <li> element.
+ * @param {?JSON} blobKey the blob key as a JSON object for the interior
+ *    image of the created <li> element. If it is null, no image element
+ *    is included in the parent <li> element.
  * @return {HTMLLIElement} The list element created.
  */
-function createListElement(text, imageUrl) {
+function createListElement(text, blobKey) {
   const liElement = document.createElement('li');
   const textElement = document.createElement('p');
   textElement.innerText = text;
   liElement.appendChild(textElement);
 
-  if (imageUrl != null) {
+  if (blobKey != null) {
     const imageElement = document.createElement('img');
-    imageElement.src = imageUrl;
+    imageElement.src = "/serve-image?blob-key="+blobKey.blobKey;
     liElement.appendChild(imageElement);
   }
   return liElement;

--- a/portfolio/src/main/webapp/scripts/server-dev.js
+++ b/portfolio/src/main/webapp/scripts/server-dev.js
@@ -104,7 +104,7 @@ function createListElement(text, blobKey) {
 
   if (blobKey != null) {
     const imageElement = document.createElement('img');
-    imageElement.src = "/serve-image?blob-key="+blobKey.blobKey;
+    imageElement.src = "/serve-image?blob-key=" + blobKey.blobKey;
     liElement.appendChild(imageElement);
   }
   return liElement;


### PR DESCRIPTION
Store and serve images using their blob key vs a generated URL.

This PR extends the changes made in #21. Previously ImageService.getServingUrl was used with the blob key for an image to generate a URL for the uploaded image. This was stored in the database and fetched from JS where is was inserted as the value of the src tag in the comment. Unfortunately due to access issues on the cloud project, this did not work when deploying the server. So rather than storing and serving the image URL, the blob key was stored and served 'manually.' This was accomplished with the following changes:
- After file input verification return the blob key rather than generating the URL pointing to the uploaded image. Store the blob key instead of the URL in datastore.
- Modify Comment class to hold a blob key rather than image URL.
- Created a servlet that handles GET requests at a page. It looks for the blob-key param in the URL query string and returns the file corresponding to the blob key.
- Change the src of the image for each comment to be the url of the image serving servlet created with the corresponding the blob key for each image if it is not null.

For testing, the same "user testing" strategy was used as described in PR #21 .