### PR TITLE
Landmark Detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 target/
 .idea
+
+step/
+.classpath
+.project
+.settings/
+.factorypath

--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -31,6 +31,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-vision</artifactId>
+      <version>1.70.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.8.6</version>

--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -23,18 +23,20 @@ import com.google.appengine.api.blobstore.BlobKey;
  */
 public class Comment {
 
-  /** The strings of text for the comment. */
+  /** The message text for the comment. */
   private final String text;
 
   /** The keys corresponding to the image stored in the Blobstore for the
       comment (null if no image for a comment). */
   private final BlobKey blobKey;
 
+  /** A landmark instance corresponding the the image given by blobKey.  */
   private final Landmark landmark;
 
   /** 
    * @param text The string of text for an individual comment.
    * @param blobKey The associated image blob key for an individual comment.
+   * @param landmark The associated landmark instance for an individual comment.
    */
   public Comment(String text, BlobKey blobKey, Landmark landmark) {
     this.text = text;

--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -23,24 +23,26 @@ import com.google.appengine.api.blobstore.BlobKey;
  */
 public class Comment {
 
-  /** The message text for the comment. */
+  /** The message content of the comment. */
   private final String text;
 
-  /** The keys corresponding to the image stored in the Blobstore for the
-      comment (null if no image for a comment). */
+  /**
+   * The keys corresponding to the image stored in the Blobstore for the comment (null if no image
+   * for a comment).
+   */
   private final BlobKey blobKey;
 
-  /** A landmark instance corresponding the the image given by blobKey.  */
+  /** A landmark instance corresponding the the image given by blobKey. */
   private final Landmark landmark;
 
-  /** 
+  /**
    * @param text The string of text for an individual comment.
    * @param blobKey The associated image blob key for an individual comment.
    * @param landmark The associated landmark instance for an individual comment.
    */
   public Comment(String text, BlobKey blobKey, Landmark landmark) {
     this.text = text;
-    this.blobKey = blobKey; 
+    this.blobKey = blobKey;
     this.landmark = landmark;
   }
 }

--- a/portfolio/src/main/java/com/google/sps/data/Landmark.java
+++ b/portfolio/src/main/java/com/google/sps/data/Landmark.java
@@ -15,21 +15,27 @@
 package com.google.sps.data;
 
 /**
- * Class representing a comment created on server-dev.html.
+ * Class representing a landmark that is part of a Comment instance.
+ * This data was generated using Landmark Detection annotation with 
+ * Cloud Vision API.
  *
  * <p>Note: The private variables in this class are converted into JSON.
  */
 public class Landmark {
 
+  /** The landmark name/decription */
   private final String name;
 
+  /** The landmark latitude */
   private final float latitude;
   
+  /** The landmark longitude */
   private final float longitude;
 
   /** 
-   * @param text The string of text for an individual comment.
-   * @param blobKey The associated image blob key for an individual comment.
+   * @param name Landmark name.
+   * @param latitude Landmark latitude.
+   * @param longitude Landmark longitude.
    */
   public Landmark(String name, float latitude, float longitude) {
     this.name = name;

--- a/portfolio/src/main/java/com/google/sps/data/Landmark.java
+++ b/portfolio/src/main/java/com/google/sps/data/Landmark.java
@@ -22,13 +22,10 @@ package com.google.sps.data;
  */
 public class Landmark {
 
-  /** The landmark name/decription */
   private final String name;
 
-  /** The landmark latitude */
   private final float latitude;
 
-  /** The landmark longitude */
   private final float longitude;
 
   /**

--- a/portfolio/src/main/java/com/google/sps/data/Landmark.java
+++ b/portfolio/src/main/java/com/google/sps/data/Landmark.java
@@ -15,9 +15,8 @@
 package com.google.sps.data;
 
 /**
- * Class representing a landmark that is part of a Comment instance.
- * This data was generated using Landmark Detection annotation with 
- * Cloud Vision API.
+ * Class representing a landmark that is part of a Comment instance. This data was generated using
+ * Landmark Detection annotation with Cloud Vision API.
  *
  * <p>Note: The private variables in this class are converted into JSON.
  */
@@ -28,18 +27,18 @@ public class Landmark {
 
   /** The landmark latitude */
   private final float latitude;
-  
+
   /** The landmark longitude */
   private final float longitude;
 
-  /** 
+  /**
    * @param name Landmark name.
    * @param latitude Landmark latitude.
    * @param longitude Landmark longitude.
    */
   public Landmark(String name, float latitude, float longitude) {
     this.name = name;
-    this.latitude = latitude; 
+    this.latitude = latitude;
     this.longitude = longitude;
   }
 }

--- a/portfolio/src/main/java/com/google/sps/data/Landmark.java
+++ b/portfolio/src/main/java/com/google/sps/data/Landmark.java
@@ -14,31 +14,26 @@
 
 package com.google.sps.data;
 
-import com.google.appengine.api.blobstore.BlobKey;
-
 /**
  * Class representing a comment created on server-dev.html.
  *
  * <p>Note: The private variables in this class are converted into JSON.
  */
-public class Comment {
+public class Landmark {
 
-  /** The strings of text for the comment. */
-  private final String text;
+  private final String name;
 
-  /** The keys corresponding to the image stored in the Blobstore for the
-      comment (null if no image for a comment). */
-  private final BlobKey blobKey;
-
-  private final Landmark landmark;
+  private final float latitude;
+  
+  private final float longitude;
 
   /** 
    * @param text The string of text for an individual comment.
    * @param blobKey The associated image blob key for an individual comment.
    */
-  public Comment(String text, BlobKey blobKey, Landmark landmark) {
-    this.text = text;
-    this.blobKey = blobKey; 
-    this.landmark = landmark;
+  public Landmark(String name, float latitude, float longitude) {
+    this.name = name;
+    this.latitude = latitude; 
+    this.longitude = longitude;
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentsServlet.java
@@ -20,10 +20,13 @@ import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.GeoPt;
+import com.google.appengine.api.datastore.GeoPt;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.sps.data.Comment;
+import com.google.sps.data.Landmark;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -52,8 +55,14 @@ public class ListCommentsServlet extends HttpServlet {
 
     List<Comment> commentsThread = new ArrayList<>();
     for (Entity commentEntity : results.asIterable()) {
+      Landmark landmark = null;
+      if (commentEntity.getProperty("landmarkName") != null) {
+        landmark = new Landmark((String) commentEntity.getProperty("landmarkName"),
+                            ((GeoPt) commentEntity.getProperty("landmarkGeoPt")).getLatitude(),
+                            ((GeoPt) commentEntity.getProperty("landmarkGeoPt")).getLongitude());
+      }
       commentsThread.add(new Comment((String) commentEntity.getProperty("text"),
-                                     (BlobKey) commentEntity.getProperty("blobKey")));
+                                     (BlobKey) commentEntity.getProperty("blobKey"),landmark));
     }
 
     String jsonComments = convertToJson(commentsThread);

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentsServlet.java
@@ -21,13 +21,12 @@ import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.GeoPt;
-import com.google.appengine.api.datastore.GeoPt;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.gson.Gson;
 import com.google.sps.data.Comment;
 import com.google.sps.data.Landmark;
-import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -57,12 +56,17 @@ public class ListCommentsServlet extends HttpServlet {
     for (Entity commentEntity : results.asIterable()) {
       Landmark landmark = null;
       if (commentEntity.getProperty("landmarkName") != null) {
-        landmark = new Landmark((String) commentEntity.getProperty("landmarkName"),
-                            ((GeoPt) commentEntity.getProperty("landmarkGeoPt")).getLatitude(),
-                            ((GeoPt) commentEntity.getProperty("landmarkGeoPt")).getLongitude());
+        landmark =
+            new Landmark(
+                (String) commentEntity.getProperty("landmarkName"),
+                ((GeoPt) commentEntity.getProperty("landmarkGeoPt")).getLatitude(),
+                ((GeoPt) commentEntity.getProperty("landmarkGeoPt")).getLongitude());
       }
-      commentsThread.add(new Comment((String) commentEntity.getProperty("text"),
-                                     (BlobKey) commentEntity.getProperty("blobKey"), landmark));
+      commentsThread.add(
+          new Comment(
+              (String) commentEntity.getProperty("text"),
+              (BlobKey) commentEntity.getProperty("blobKey"),
+              landmark));
     }
 
     String jsonComments = convertToJson(commentsThread);
@@ -74,7 +78,7 @@ public class ListCommentsServlet extends HttpServlet {
    * Converts a list of Comment objects to a JSON string.
    *
    * @param commentsThread The List of Comment objects that should be converted to a JSON string.
-   * @return               The JSON string corresponding to the list of comments.
+   * @return The JSON string corresponding to the list of comments.
    */
   private String convertToJson(List<Comment> commentsThread) {
     Gson gson = new Gson();

--- a/portfolio/src/main/java/com/google/sps/servlets/ListCommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ListCommentsServlet.java
@@ -62,7 +62,7 @@ public class ListCommentsServlet extends HttpServlet {
                             ((GeoPt) commentEntity.getProperty("landmarkGeoPt")).getLongitude());
       }
       commentsThread.add(new Comment((String) commentEntity.getProperty("text"),
-                                     (BlobKey) commentEntity.getProperty("blobKey"),landmark));
+                                     (BlobKey) commentEntity.getProperty("blobKey"), landmark));
     }
 
     String jsonComments = convertToJson(commentsThread);

--- a/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
@@ -60,6 +60,9 @@ public class NewCommentServlet extends HttpServlet {
    * stored in the Datastore Blobstore. The POST request also results in a re-direct back to the
    * original server-dev page.
    *
+   * <p> If there is no image uploaded or there is no landmark in the image, the landmark name 
+   * and geo point uploaded to the Datastore will be null.
+   *
    * <p>TODO(Issue #15): Do verfification on a new comment before adding it to the comments list.
    */
   @Override
@@ -134,6 +137,11 @@ public class NewCommentServlet extends HttpServlet {
   /**
    * Blobstore stores files as binary data. This function retrieves the binary data stored at the
    * BlobKey parameter.
+   *
+   * @param blobKey The key associated with the image whose binary data is retrieved.
+   * @return An byte array containing the binary data of the image associated with the blobKey.
+   * @throws IOException - If an output error occurs when writing bytes from the temp blobstore 
+   *                       buffer <code>b</code> to the output byte array <code>outputBytes</code>.
    */
   private byte[] getBlobBytes(BlobKey blobKey) throws IOException {
     BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
@@ -167,6 +175,8 @@ public class NewCommentServlet extends HttpServlet {
    * @return An landmark annotation object containing information such as name and coordinates for
    *     the landmark detected in the image. Null if there are no landmarks detected or other errors
    *     occur when obtaining the landmark information.
+   * @throws IOException - If an input or output error occurs when creating the 
+   *                       <code>ImageAnnotatorClient</code> object.
    */
   private List<EntityAnnotation> getLandmarkInfo(byte[] imgBytes) throws IOException {
     ByteString byteString = ByteString.copyFrom(imgBytes);

--- a/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
@@ -67,18 +67,20 @@ public class NewCommentServlet extends HttpServlet {
     String newComment = request.getParameter("comment");
     long timestamp = System.currentTimeMillis();
     BlobKey blobKey = getBlobKey(request, "image");
-
-    byte[] blobBytes = getBlobBytes(blobKey);
-    List<EntityAnnotation> landmarkInfoList = getLandmarkInfo(blobBytes);
-    System.out.println(landmarkInfoList);
     String landmarkName = null;
     GeoPt landmarkGeoPt = null;
-    if (landmarkInfoList.size() > 0) {
-      EntityAnnotation landmarkInfo = landmarkInfoList.get(0);
-      landmarkName = landmarkInfo.getDescription();
-      LatLng landmarkLatLng = landmarkInfo.getLocationsList().listIterator().next().getLatLng();
-      landmarkGeoPt = new GeoPt((float) landmarkLatLng.getLatitude(), 
-                                (float) landmarkLatLng.getLongitude());
+    
+    if (blobKey != null) {
+      byte[] blobBytes = getBlobBytes(blobKey);
+      List<EntityAnnotation> landmarkInfoList = getLandmarkInfo(blobBytes);
+ 
+      if (landmarkInfoList.size() > 0) {
+        EntityAnnotation landmarkInfo = landmarkInfoList.get(0);
+        landmarkName = landmarkInfo.getDescription();
+        LatLng landmarkLatLng = landmarkInfo.getLocationsList().listIterator().next().getLatLng();
+        landmarkGeoPt = new GeoPt((float) landmarkLatLng.getLatitude(), 
+                                  (float) landmarkLatLng.getLongitude());
+      }
     }
 
     Entity taskEntity = new Entity("Comment");

--- a/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
@@ -72,12 +72,12 @@ public class NewCommentServlet extends HttpServlet {
     BlobKey blobKey = getBlobKey(request, "image");
     String landmarkName = null;
     GeoPt landmarkGeoPt = null;
-    
+
     if (blobKey != null) {
       byte[] blobBytes = getBlobBytes(blobKey);
       List<EntityAnnotation> landmarkInfoList = getLandmarkInfo(blobBytes);
 
-      if (!landmarkInfoList.isEmpty()) {
+      if (landmarkInfoList != null && !landmarkInfoList.isEmpty()) {
         EntityAnnotation landmarkInfo = landmarkInfoList.get(0);
         landmarkName = landmarkInfo.getDescription();
         LatLng landmarkLatLng = landmarkInfo.getLocationsList().listIterator().next().getLatLng();

--- a/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
@@ -77,7 +77,7 @@ public class NewCommentServlet extends HttpServlet {
       byte[] blobBytes = getBlobBytes(blobKey);
       List<EntityAnnotation> landmarkInfoList = getLandmarkInfo(blobBytes);
  
-      if (landmarkInfoList.size() > 0) {
+      if (landmarkInfoList.isEmpty() == false) {
         EntityAnnotation landmarkInfo = landmarkInfoList.get(0);
         landmarkName = landmarkInfo.getDescription();
         LatLng landmarkLatLng = landmarkInfo.getLocationsList().listIterator().next().getLatLng();

--- a/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
@@ -22,6 +22,7 @@ import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.GeoPt;
 import com.google.cloud.vision.v1.AnnotateImageRequest;
 import com.google.cloud.vision.v1.AnnotateImageResponse;
 import com.google.cloud.vision.v1.BatchAnnotateImagesResponse;
@@ -31,7 +32,6 @@ import com.google.cloud.vision.v1.Image;
 import com.google.cloud.vision.v1.ImageAnnotatorClient;
 import com.google.protobuf.ByteString;
 import com.google.type.LatLng;
-import com.google.appengine.api.datastore.GeoPt;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -60,8 +60,8 @@ public class NewCommentServlet extends HttpServlet {
    * stored in the Datastore Blobstore. The POST request also results in a re-direct back to the
    * original server-dev page.
    *
-   * <p> If there is no image uploaded or there is no landmark in the image, the landmark name 
-   * and geo point uploaded to the Datastore will be null.
+   * <p>If there is no image uploaded or there is no landmark in the image, the landmark name and
+   * geo point uploaded to the Datastore will be null.
    *
    * <p>TODO(Issue #15): Do verfification on a new comment before adding it to the comments list.
    */
@@ -75,13 +75,13 @@ public class NewCommentServlet extends HttpServlet {
     if (blobKey != null) {
       byte[] blobBytes = getBlobBytes(blobKey);
       List<EntityAnnotation> landmarkInfoList = getLandmarkInfo(blobBytes);
- 
+
       if (!landmarkInfoList.isEmpty()) {
         EntityAnnotation landmarkInfo = landmarkInfoList.get(0);
         landmarkName = landmarkInfo.getDescription();
         LatLng landmarkLatLng = landmarkInfo.getLocationsList().listIterator().next().getLatLng();
-        landmarkGeoPt = new GeoPt((float) landmarkLatLng.getLatitude(), 
-                                  (float) landmarkLatLng.getLongitude());
+        landmarkGeoPt =
+            new GeoPt((float) landmarkLatLng.getLatitude(), (float) landmarkLatLng.getLongitude());
       }
     }
 
@@ -91,7 +91,7 @@ public class NewCommentServlet extends HttpServlet {
     taskEntity.setProperty("blobKey", blobKey);
     taskEntity.setProperty("landmarkName", landmarkName);
     taskEntity.setProperty("landmarkGeoPt", landmarkGeoPt);
-    
+
     datastore.put(taskEntity);
 
     response.sendRedirect("/pages/server-dev.html");
@@ -100,7 +100,7 @@ public class NewCommentServlet extends HttpServlet {
   /**
    * Returns a BlobKey object corresponding to the uploaded file.
    *
-   * @param request The <code>HttpServletRequest</code> for the POST request.
+   * @param request The {@code HttpServletRequest} for the POST request.
    * @param formInputElementName The name attribute of the image file input to the form.
    * @return The blob key associated with the uploaded image file. Null is returned if the user did
    *     not select a file or the file is not an image type.
@@ -124,7 +124,7 @@ public class NewCommentServlet extends HttpServlet {
       return null;
     }
 
-    // Ensure that uploaded file is an image file.
+    // Non-image files are not supported.
     if (blobInfo.getContentType().startsWith("image") == false) {
       blobstoreService.delete(blobKey);
       return null;
@@ -139,8 +139,8 @@ public class NewCommentServlet extends HttpServlet {
    *
    * @param blobKey The key associated with the image whose binary data is retrieved.
    * @return An byte array containing the binary data of the image associated with the blobKey.
-   * @throws IOException - If an output error occurs when writing bytes from the temp blobstore 
-   *                       buffer <code>b</code> to the output byte array <code>outputBytes</code>.
+   * @throws IOException - If an output error occurs when writing bytes from the temp blobstore
+   *     buffer {@code b} to the output byte array {@code outputBytes}.
    */
   private byte[] getBlobBytes(BlobKey blobKey) throws IOException {
     BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
@@ -174,8 +174,8 @@ public class NewCommentServlet extends HttpServlet {
    * @return An landmark annotation object containing information such as name and coordinates for
    *     the landmark detected in the image. Null if there are no landmarks detected or other errors
    *     occur when obtaining the landmark information.
-   * @throws IOException - If an input or output error occurs when creating the 
-   *                       <code>ImageAnnotatorClient</code> object.
+   * @throws IOException - If an input or output error occurs when creating the {@code
+   *     ImageAnnotatorClient} object.
    */
   private List<EntityAnnotation> getLandmarkInfo(byte[] imgBytes) throws IOException {
     ByteString byteString = ByteString.copyFrom(imgBytes);

--- a/portfolio/src/main/java/com/google/sps/servlets/ServeBlobs.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ServeBlobs.java
@@ -17,17 +17,7 @@ package com.google.sps.servlets;
 import com.google.appengine.api.blobstore.BlobKey;
 import com.google.appengine.api.blobstore.BlobstoreService;
 import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
-import com.google.appengine.api.datastore.DatastoreService;
-import com.google.appengine.api.datastore.DatastoreServiceFactory;
-import com.google.appengine.api.datastore.Entity;
-import com.google.appengine.api.datastore.PreparedQuery;
-import com.google.appengine.api.datastore.Query;
-import com.google.appengine.api.datastore.Query.SortDirection;
-import com.google.sps.data.Comment;
-import com.google.gson.Gson;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -41,8 +31,8 @@ public class ServeBlobs extends HttpServlet {
   /**
    * {@inheritDoc}
    *
-   * <p>This Method handles GET requests in order to serve files uploaded to Blobstore based on 
-   * the blob key placed in the URL query string. 
+   * <p>This Method handles GET requests in order to serve files uploaded to Blobstore based on the
+   * blob key placed in the URL query string.
    */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/portfolio/src/main/webapp/scripts/server-dev.js
+++ b/portfolio/src/main/webapp/scripts/server-dev.js
@@ -15,7 +15,7 @@
 
 /**
  * Fetches the previously entered comments from the server and inserts each
- * comment as a list item of the 'comments' <ul> element.
+ * comment as a list item of the 'comments-thread-container' <ul> element.
  * 
  * The number of comments displayed is determined by 
  * getNumCommentstoDisplay().
@@ -84,15 +84,17 @@ function getNumCommentstoDisplay(numComments) {
 }
 
 /**
- * Creates an <li> element containing the comment text and image.
+ * Creates an <li> element containing the comment data.
  *
- * If there the imageUrl is null, no image element is included in 
- * parent <li> element. 
+ * Each comment contains a message text, image, landmark name/location,
+ * and landmark latitude-longitude coordinates. However, both the blobKey
+ * and landmark fields of the comment JSON object can be null. If the  
+ * blobKey value null, no image element is included in the parent <li> element.
+ * If the landmark value is null, no landmark information is included. 
  * 
- * @param {string} text the interior text of the created <li> element.
- * @param {?JSON} blobKey the blob key as a JSON object for the interior
- *    image of the created <li> element. If it is null, no image element
- *    is included in the parent <li> element.
+ * @param {JSON} commentInJson A string that contains a JSON object of an 
+ *    individual comment. This JSON object contains fields for message text,
+ *    image, landmark name, and landmark latitude-longitude coordinates.
  * @return {HTMLLIElement} The list element created.
  */
 function createListElement(commentInJson) {

--- a/portfolio/src/main/webapp/scripts/server-dev.js
+++ b/portfolio/src/main/webapp/scripts/server-dev.js
@@ -68,7 +68,7 @@ function getNumCommentstoDisplay(numComments) {
   let newNumCommentsToDisplay = urlParams.get('num-comments');
   const currNumCommentsToDisplay = parseInt(
       sessionStorage.getItem('currNumCommentsToDisplay'));
-  
+
   if (newNumCommentsToDisplay == null) {
     if (isNaN(currNumCommentsToDisplay)) {
       const defaultNumComments = document.getElementById('num-comments').value;

--- a/portfolio/src/main/webapp/scripts/server-dev.js
+++ b/portfolio/src/main/webapp/scripts/server-dev.js
@@ -31,9 +31,8 @@ function getCommentsThread() {
             getElementById('comments-thread-container');
         commentsThreadContainer.innerHTML = '';
         for (let cmntIdx = 0; cmntIdx < numCommentsToDisplay; cmntIdx++) {
-          commentsThreadContainer.appendChild(createListElement(
-                                          commentsThread[cmntIdx].text,
-                                          commentsThread[cmntIdx].blobKey));
+          commentsThreadContainer.appendChild(
+              createListElement(commentsThread[cmntIdx]));
         }
       })
       .catch(err => {
@@ -96,7 +95,11 @@ function getNumCommentstoDisplay(numComments) {
  *    is included in the parent <li> element.
  * @return {HTMLLIElement} The list element created.
  */
-function createListElement(text, blobKey) {
+function createListElement(commentInJson) {
+  const text = commentInJson.text;
+  const blobKey = commentInJson.blobKey;
+  const landmark = commentInJson.landmark;
+
   const liElement = document.createElement('li');
   const textElement = document.createElement('p');
   textElement.innerText = text;
@@ -106,6 +109,16 @@ function createListElement(text, blobKey) {
     const imageElement = document.createElement('img');
     imageElement.src = "/serve-image?blob-key="+blobKey.blobKey;
     liElement.appendChild(imageElement);
+  }
+
+  if (landmark != null) {
+    const landmarkNameElement = document.createElement('p');
+    landmarkNameElement.innerText = landmark.name;
+    const landmarkLatLng = document.createElement('p');
+    landmarkLatLng.innerText = "(" + landmark.latitude + ", " +
+                                          landmark.longitude + ")";
+    liElement.appendChild(landmarkNameElement);
+    liElement.appendChild(landmarkLatLng);
   }
   return liElement;
 }


### PR DESCRIPTION
Add functionality to provide information on detected landmarks in images submitted in a new comment.

This PR extends the changes made in #22. The integration of this functionality involved the following steps:
- Added functionality to retrieve a byte array for the image uploaded.
- Used Cloud Vision's Landmark Detection API to get a landmark annotation list based from the image.
- Add landmark name and coordinates (GeoPt) as properties for the comment kind in the Datastore.
- Creation of a new class, Landmark, that contains the name and location data for a landmark. An instance of this is contained within each comment instance. Null if there is no landmark.
- Modify server-dev.js to create and include an two extra tags for the landmark name and latitude/longitude coordinates in each comment where a landmark was detected.

Testing was carried out similar to the strategy provided in #21 .  Additional test were also run to test the effectiveness of the landmark detection of Cloud Vision API for fun:
- For images that should not be detected, images such as food, people, and nature (a single tree) were tested as cases where no landmarks should be detected. These were all successful. 
- For images that should be recognized as landmarks, images of Saint Basil's Cathedral (example on tutorial), New York City, Ulun Danu Beratan Temple in Indonesia, and the Easter Island Sculptures were tested. all of these except for the Easter Island Sculptures were successful.