### PR TITLE
Initial Implementation of 'Find Meeting Times' Algorithm

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -117,15 +117,6 @@ public final class FindMeetingQuery {
                 })
             .collect(Collectors.toList());
 
-    // Collections.sort(
-    //     eventList,
-    //     new Comparator<Event>() {
-    //       @Override
-    //       public int compare(Event a, Event b) {
-    //         return Long.compare(a.getWhen().start(), b.getWhen().start());
-    //       }
-    //     });
-
     return getMeettingTimes(eventList, request);
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -16,13 +16,11 @@ package com.google.sps;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.stream.Collectors;
 import java.util.Comparator;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public final class FindMeetingQuery {
   /**
@@ -105,20 +103,28 @@ public final class FindMeetingQuery {
    * @return A Collection of the feasible meeting {@code TimeRange}s.
    */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    List<Event> eventList = events.stream()
-                                  .filter(event -> eventParticipantInMeeting(
-                                      new HashSet<String>(event.getAttendees()), 
-                                      request.getAttendees()))
-                                  .collect(Collectors.toList());
+    List<Event> eventList =
+        events.stream()
+            .filter(
+                event -> eventParticipantInMeeting(
+                    new HashSet<String>(event.getAttendees()), request.getAttendees()))
+            .sorted(
+                new Comparator<Event>() {
+                  @Override
+                  public int compare(Event a, Event b) {
+                    return Long.compare(a.getWhen().start(), b.getWhen().start());
+                  }
+                })
+            .collect(Collectors.toList());
 
-    Collections.sort(
-        eventList,
-        new Comparator<Event>() {
-          @Override
-          public int compare(Event a, Event b) {
-            return Long.compare(a.getWhen().start(), b.getWhen().start());
-          }
-        });
+    // Collections.sort(
+    //     eventList,
+    //     new Comparator<Event>() {
+    //       @Override
+    //       public int compare(Event a, Event b) {
+    //         return Long.compare(a.getWhen().start(), b.getWhen().start());
+    //       }
+    //     });
 
     return getMeettingTimes(eventList, request);
   }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -15,9 +15,72 @@
 package com.google.sps;
 
 import java.util.Collection;
+import java.util.Collections;
+import com.google.sps.Event;
+import com.google.sps.TimeRange;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.Iterator;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 public final class FindMeetingQuery {
+  private boolean eventParticipantInMeeting(Set<String> eventAttendees, 
+                                              Collection<String> meetingAttendees) {
+    for (String eventAttendee : eventAttendees) {
+      if (meetingAttendees.contains(eventAttendee)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    throw new UnsupportedOperationException("TODO: Implement this method.");
+    Collection<TimeRange> openMeetingTimes = new ArrayList<>();
+    List<Event> eventList = new ArrayList<>(events);
+
+    // Remove any events where there are no participants in event that are in meeting request.
+    for(Iterator<Event> it = eventList.iterator(); it.hasNext();) {
+      Event cur = it.next();
+      if (eventParticipantInMeeting(cur.getAttendees(), request.getAttendees()) == false) {
+        it.remove();
+      }
+    }
+    Collections.sort(eventList, new Comparator<Event>() {
+      @Override
+      public int compare(Event a, Event b) {
+        return Long.compare(a.getWhen().start(), b.getWhen().start());
+      }
+    });
+
+    // Create start/end of day reference points to avoid extra conditionals outside main loop.
+    eventList.add(new Event("EOD", 
+        TimeRange.fromStartDuration(TimeRange.END_OF_DAY,0), request.getAttendees()));
+    int endOfEarlierEvent = TimeRange.START_OF_DAY;
+    
+    for (int i = 0; i < eventList.size(); i++) {
+      Event curEvent = eventList.get(i);
+      int startOfCurEvent = curEvent.getWhen().start();
+
+      boolean endTimeIsInclusive = false;
+      if ("EOD".equals(curEvent.getTitle())) {
+        endTimeIsInclusive = true;
+      }
+      TimeRange timeBetweenEvents = TimeRange.fromStartEnd(endOfEarlierEvent, 
+                                        startOfCurEvent, endTimeIsInclusive);
+      if (timeBetweenEvents.duration() >= request.getDuration()) {
+        openMeetingTimes.add(timeBetweenEvents);
+      }
+
+      // Only move reference points of end of last event if the cur event end point is later 
+      // than the end of the event with the latest end point so far.
+      int endOfCurEvent = curEvent.getWhen().end();
+      if (endOfCurEvent >= endOfEarlierEvent) {
+        endOfEarlierEvent = endOfCurEvent;
+      }
+    }
+
+    return openMeetingTimes;
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -72,10 +72,7 @@ public final class FindMeetingQuery {
 
       // Only move reference points of end of last event if the cur event end point is later
       // than the end of the event with the latest end point so far.
-      int endOfCurEvent = curEvent.getWhen().end();
-      if (endOfCurEvent >= endOfEarlierEvent) {
-        endOfEarlierEvent = endOfCurEvent;
-      }
+      endOfEarlierEvent = max(endOfEarlierEvent, curEvent.getWhen().end());
     }
 
     return openMeetingTimes;

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -35,10 +35,7 @@ public final class FindMeetingQuery {
   private boolean eventParticipantInMeeting(
       Set<String> eventAttendeesCopy, Collection<String> meetingAttendees) {
     eventAttendeesCopy.retainAll(meetingAttendees);
-    if (eventAttendeesCopy.isEmpty()) {
-      return false;
-    }
-    return true;
+    return !eventAttendeesCopy.isEmpty();
   }
 
   /**
@@ -56,15 +53,14 @@ public final class FindMeetingQuery {
    * @param request The meeting request that contains the requirements for potential meetings.
    * @return A Collection of the feasible meeting {@code TimeRange}s.
    */
-  private Collection<TimeRange> getMeettingTimes(List<Event> eventList, MeetingRequest request) {
+  private Collection<TimeRange> getMeetingTimes(List<Event> eventList, MeetingRequest request) {
     eventList.add(
         new Event(
             "EOD", TimeRange.fromStartDuration(TimeRange.END_OF_DAY, 0), request.getAttendees()));
     int endOfEarlierEvent = TimeRange.START_OF_DAY;
 
     Collection<TimeRange> openMeetingTimes = new ArrayList<>();
-    for (int i = 0; i < eventList.size(); i++) {
-      Event curEvent = eventList.get(i);
+    for (Event curEvent : eventList) {
       int startOfCurEvent = curEvent.getWhen().start();
 
       boolean endTimeIsInclusive = "EOD".equals(curEvent.getTitle());
@@ -114,6 +110,6 @@ public final class FindMeetingQuery {
                 })
             .collect(Collectors.toList());
 
-    return getMeettingTimes(eventList, request);
+    return getMeetingTimes(eventList, request);
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -54,9 +54,8 @@ public final class FindMeetingQuery {
    * @return A Collection of the feasible meeting {@code TimeRange}s.
    */
   private Collection<TimeRange> getMeetingTimes(List<Event> eventList, MeetingRequest request) {
-    eventList.add(
-        new Event(
-            "EOD", TimeRange.fromStartDuration(TimeRange.END_OF_DAY, 0), request.getAttendees()));
+    eventList.add(new Event(
+        "EOD", TimeRange.fromStartDuration(TimeRange.END_OF_DAY, 0), request.getAttendees()));
     int endOfEarlierEvent = TimeRange.START_OF_DAY;
 
     Collection<TimeRange> openMeetingTimes = new ArrayList<>();
@@ -98,16 +97,15 @@ public final class FindMeetingQuery {
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
     List<Event> eventList =
         events.stream()
-            .filter(
-                event -> eventParticipantInMeeting(
+            .filter(event
+                -> eventParticipantInMeeting(
                     new HashSet<String>(event.getAttendees()), request.getAttendees()))
-            .sorted(
-                new Comparator<Event>() {
-                  @Override
-                  public int compare(Event a, Event b) {
-                    return Long.compare(a.getWhen().start(), b.getWhen().start());
-                  }
-                })
+            .sorted(new Comparator<Event>() {
+              @Override
+              public int compare(Event a, Event b) {
+                return Long.compare(a.getWhen().start(), b.getWhen().start());
+              }
+            })
             .collect(Collectors.toList());
 
     return getMeetingTimes(eventList, request);

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -54,15 +54,16 @@ public final class FindMeetingQuery {
    * @return A Collection of the feasible meeting {@code TimeRange}s.
    */
   private Collection<TimeRange> getMeetingTimes(List<Event> eventList, MeetingRequest request) {
+    String eod_title = "EOD";
     eventList.add(new Event(
-        "EOD", TimeRange.fromStartDuration(TimeRange.END_OF_DAY, 0), request.getAttendees()));
+        eod_title, TimeRange.fromStartDuration(TimeRange.END_OF_DAY, 0), request.getAttendees()));
     int endOfEarlierEvent = TimeRange.START_OF_DAY;
 
     Collection<TimeRange> openMeetingTimes = new ArrayList<>();
     for (Event curEvent : eventList) {
       int startOfCurEvent = curEvent.getWhen().start();
 
-      boolean endTimeIsInclusive = "EOD".equals(curEvent.getTitle());
+      boolean endTimeIsInclusive = eod_title.equals(curEvent.getTitle());
       TimeRange timeBetweenEvents =
           TimeRange.fromStartEnd(endOfEarlierEvent, startOfCurEvent, endTimeIsInclusive);
       if (timeBetweenEvents.duration() >= request.getDuration()) {

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -14,20 +14,26 @@
 
 package com.google.sps;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import com.google.sps.Event;
-import com.google.sps.TimeRange;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.Iterator;
-import java.util.ArrayList;
-import java.util.Arrays;
 
 public final class FindMeetingQuery {
-  private boolean eventParticipantInMeeting(Set<String> eventAttendees, 
-                                              Collection<String> meetingAttendees) {
+  /**
+   * Returns a boolean based on if at least one participant in the event is also a participant in
+   * the meeting request.
+   *
+   * @param eventAttendees The set of attendees in a specific event.
+   * @param meetingAttendees The set of attendees in the meeting request.
+   * @return True if at least one participant in the set {@code eventAttendees} is also a
+   *     participant in {@code meetingAttendees}. False otherwise.
+   */
+  private boolean eventParticipantInMeeting(
+      Set<String> eventAttendees, Collection<String> meetingAttendees) {
     for (String eventAttendee : eventAttendees) {
       if (meetingAttendees.contains(eventAttendee)) {
         return true;
@@ -36,29 +42,45 @@ public final class FindMeetingQuery {
     return false;
   }
 
-  public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    Collection<TimeRange> openMeetingTimes = new ArrayList<>();
-    List<Event> eventList = new ArrayList<>(events);
-
-    // Remove any events where there are no participants in event that are in meeting request.
-    for(Iterator<Event> it = eventList.iterator(); it.hasNext();) {
+  /**
+   * Remove any events where it does not contains at least one participant that is included in the
+   * meeting request.
+   *
+   * @param eventList The list of events that are used to determine what periods of time that the
+   *     meeting can take place. This list is 'filtered' and sorted in {@code query()}.
+   * @param request The meeting request that contains the requirements for potential meetings.
+   */
+  private void removeEventsWithNoMeetingAttendees(List<Event> eventList, MeetingRequest request) {
+    for (Iterator<Event> it = eventList.iterator(); it.hasNext(); ) {
       Event cur = it.next();
       if (eventParticipantInMeeting(cur.getAttendees(), request.getAttendees()) == false) {
         it.remove();
       }
     }
-    Collections.sort(eventList, new Comparator<Event>() {
-      @Override
-      public int compare(Event a, Event b) {
-        return Long.compare(a.getWhen().start(), b.getWhen().start());
-      }
-    });
+  }
 
-    // Create start/end of day reference points to avoid extra conditionals outside main loop.
-    eventList.add(new Event("EOD", 
-        TimeRange.fromStartDuration(TimeRange.END_OF_DAY,0), request.getAttendees()));
+  /**
+   * Returns a collection of all meeting times that will work for all attendees' schedules.
+   *
+   * <p>The open meeting times are determined by iterating through each event and creating a new
+   * {@code TimeRange} for each range between meetings. If the duration is greater than or equal to
+   * the duration of the requested meeting, that {@code TimeRange} instance is added to the list
+   * {@code openMeetingTimes}. The initial value of {@code endOfEarlierEvent} is set to the start of
+   * the day for convenience when evaluating the first event. Also, the end of day time is appended
+   * as an additional event to the current event list to avoid more conditional statements.
+   *
+   * @param eventList The list of events that are used to determine what periods of time that the
+   *     meeting can take place. This list is 'filtered' and sorted in {@code query()}.
+   * @param request The meeting request that contains the requirements for potential meetings.
+   * @return A Collection of the feasible meeting {@code TimeRange}s.
+   */
+  private Collection<TimeRange> getMeettingTimes(List<Event> eventList, MeetingRequest request) {
+    eventList.add(
+        new Event(
+            "EOD", TimeRange.fromStartDuration(TimeRange.END_OF_DAY, 0), request.getAttendees()));
     int endOfEarlierEvent = TimeRange.START_OF_DAY;
-    
+
+    Collection<TimeRange> openMeetingTimes = new ArrayList<>();
     for (int i = 0; i < eventList.size(); i++) {
       Event curEvent = eventList.get(i);
       int startOfCurEvent = curEvent.getWhen().start();
@@ -67,13 +89,13 @@ public final class FindMeetingQuery {
       if ("EOD".equals(curEvent.getTitle())) {
         endTimeIsInclusive = true;
       }
-      TimeRange timeBetweenEvents = TimeRange.fromStartEnd(endOfEarlierEvent, 
-                                        startOfCurEvent, endTimeIsInclusive);
+      TimeRange timeBetweenEvents =
+          TimeRange.fromStartEnd(endOfEarlierEvent, startOfCurEvent, endTimeIsInclusive);
       if (timeBetweenEvents.duration() >= request.getDuration()) {
         openMeetingTimes.add(timeBetweenEvents);
       }
 
-      // Only move reference points of end of last event if the cur event end point is later 
+      // Only move reference points of end of last event if the cur event end point is later
       // than the end of the event with the latest end point so far.
       int endOfCurEvent = curEvent.getWhen().end();
       if (endOfCurEvent >= endOfEarlierEvent) {
@@ -82,5 +104,35 @@ public final class FindMeetingQuery {
     }
 
     return openMeetingTimes;
+  }
+
+  /**
+   * Returns a collection of all meeting times that will work for all attendees' schedules.
+   *
+   * <p>To determine the meeting times ({@code TimeRange}s) that works for all attendees, the event
+   * list is filtered and sorted so that {@code getMeetingTimes()} can determine all feasible
+   * meeting times. More specifically, filtered means that an event is removed if it does not
+   * contain at least one participant that is included in the meeting request.
+   *
+   * @param events The Collection of events that are used to determine what periods of time that the
+   *     meeting can take place.
+   * @param request The Meeting request that contains the requirements for potential meetings.
+   * @return A Collection of the feasible meeting {@code TimeRange}s.
+   */
+  public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
+    List<Event> eventList = new ArrayList<>(events);
+
+    removeEventsWithNoMeetingAttendees(eventList, request);
+
+    Collections.sort(
+        eventList,
+        new Comparator<Event>() {
+          @Override
+          public int compare(Event a, Event b) {
+            return Long.compare(a.getWhen().start(), b.getWhen().start());
+          }
+        });
+
+    return getMeettingTimes(eventList, request);
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -67,10 +67,7 @@ public final class FindMeetingQuery {
       Event curEvent = eventList.get(i);
       int startOfCurEvent = curEvent.getWhen().start();
 
-      boolean endTimeIsInclusive = false;
-      if ("EOD".equals(curEvent.getTitle())) {
-        endTimeIsInclusive = true;
-      }
+      boolean endTimeIsInclusive = "EOD".equals(curEvent.getTitle());
       TimeRange timeBetweenEvents =
           TimeRange.fromStartEnd(endOfEarlierEvent, startOfCurEvent, endTimeIsInclusive);
       if (timeBetweenEvents.duration() >= request.getDuration()) {

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -27,19 +28,18 @@ public final class FindMeetingQuery {
    * Returns a boolean based on if at least one participant in the event is also a participant in
    * the meeting request.
    *
-   * @param eventAttendees The set of attendees in a specific event.
+   * @param eventAttendeesCopy A copy of the set of attendees in a specific event.
    * @param meetingAttendees The set of attendees in the meeting request.
    * @return True if at least one participant in the set {@code eventAttendees} is also a
    *     participant in {@code meetingAttendees}. False otherwise.
    */
   private boolean eventParticipantInMeeting(
-      Set<String> eventAttendees, Collection<String> meetingAttendees) {
-    for (String eventAttendee : eventAttendees) {
-      if (meetingAttendees.contains(eventAttendee)) {
-        return true;
-      }
+      Set<String> eventAttendeesCopy, Collection<String> meetingAttendees) {
+    eventAttendeesCopy.retainAll(meetingAttendees);
+    if (eventAttendeesCopy.isEmpty()) {
+      return false;
     }
-    return false;
+    return true;
   }
 
   /**
@@ -53,7 +53,8 @@ public final class FindMeetingQuery {
   private void removeEventsWithNoMeetingAttendees(List<Event> eventList, MeetingRequest request) {
     for (Iterator<Event> it = eventList.iterator(); it.hasNext(); ) {
       Event cur = it.next();
-      if (eventParticipantInMeeting(cur.getAttendees(), request.getAttendees()) == false) {
+      if (!eventParticipantInMeeting(new HashSet<String>(cur.getAttendees()), 
+                                     request.getAttendees())) {
         it.remove();
       }
     }


### PR DESCRIPTION
Implement initial algorithm that finds all potential meeting time ranges with a set of participants, duration of meeting, and set of existing events.

This algorithm implemented the query method in FindMeetingQuery class in order to pass all of the pre-written tests in FindMeetingQueryTest.java. The algorithm's asymptotic time complexity is bottle-necked by Collections.sort() which is worst case O(n log n), where n is the number of events. This is only the case if we assume that the number of attendees in each event is limited to a fairly small number. If the average number of attendees within each event cannot be assumed to be small, then the worst case time complexity would be O(n*m) where m is the number of attendees for a single event.

The general steps in the algorithm:
- Remove any events where it does not contains at least one participant that is included in the meeting request.
- Sort the remaining list of events based on start time.
- Create a start and end of day reference points (create an int for start time and add end time to the event list) to avoid having to add additional conditional statements.
- Loop through each event and see if the amount of time between the current event start time and the earlier event end time is greater than or equal to the requested meeting duration.

As mentioned above the initial algorithm was tested with unit tests that were pre-written to test the query method. In a future PR, more tests will be added when implementing optional attendees.