### PR TITLE
Optional Attendees for 'Find Meeting Times' Algorithm

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -41,16 +41,6 @@ public final class FindMeetingQuery {
   /**
    * Returns a collection of all meeting times that will work for all attendees' schedules.
    *
-   * <p>Initially, the meeting attendees is set based on {@code considerOptionalAttendees}. Once
-   * this is determined, the event list is filtered and sorted. More specifically, the events are
-   * filtered if it does not contain at least one participant that is also a meeting participant.
-   * The open meeting times are determined by iterating through each event and creating a new {@code
-   * TimeRange} for each range between meetings. If the duration is greater than or equal to the
-   * duration of the requested meeting, that {@code TimeRange} instance is added to the list {@code
-   * openMeetingTimes}. The initial value of {@code endOfEarlierEvent} is set to the start of the
-   * day for convenience when evaluating the first event. Also, the end of day time is appended as
-   * an additional event to the current event list to avoid more conditional statements.
-   *
    * @param eventList The list of events that are used to determine what periods of time that the
    *     meeting can take place. This list is 'filtered' and sorted in {@code query()}.
    * @param request The meeting request that contains the requirements for potential meetings.
@@ -76,10 +66,14 @@ public final class FindMeetingQuery {
             })
             .collect(Collectors.toList());
 
+    //  The initial value of {@code endOfEarlierEvent} is set to the start of the
+    //  day for convenience when evaluating the first event.
+    int endOfEarlierEvent = TimeRange.START_OF_DAY;
+    // The end of day time is appended as an additional event to the current
+    // event list to avoid more conditional statements.
     String eod_title = "EOD";
     eventList.add(new Event(
         eod_title, TimeRange.fromStartDuration(TimeRange.END_OF_DAY, 0), request.getAttendees()));
-    int endOfEarlierEvent = TimeRange.START_OF_DAY;
 
     Collection<TimeRange> openMeetingTimes = new ArrayList<>();
     for (Event curEvent : eventList) {

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -113,8 +113,8 @@ public final class FindMeetingQuery {
     // In the special case where there are no mandatory attendees, at least one optional attendee,
     // and no times work out, return an empty list rather than considering only mandatory attendees.
     // This will result in a time range for the whole day and is not desirable.
-    if (!mandatoryAndOptionalTimesList.isEmpty()
-        || request.getAttendees().isEmpty() && !request.getOptionalAttendees().isEmpty()) {
+    if (!mandatoryAndOptionalTimesList.isEmpty() ||
+          (request.getAttendees().isEmpty() && !request.getOptionalAttendees().isEmpty())) {
       return mandatoryAndOptionalTimesList;
     }
 

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -15,7 +15,6 @@
 package com.google.sps;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -107,10 +106,8 @@ public final class FindMeetingQuery {
    * Returns a collection of all meeting times that will work for attendees' schedules.
    *
    * <p>Initially, meeting times ({@code TimeRange}s) that will works for both mandatory and
-   * optional attendies are identified. If there are no meeting times that work for all attendees,
-   * only meeting times with mandatory attendees are identified and returned. In the special case
-   * where there are no mandatory attendees, at least one optional attendee, and no times work out,
-   * return an empty list.
+   * optional attendees are identified. If there are no meeting times that work for all attendees,
+   * only meeting times with mandatory attendees are identified and returned.
    *
    * @param events The Collection of events that are used to determine what periods of time that the
    *     meeting can take place.
@@ -120,11 +117,13 @@ public final class FindMeetingQuery {
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
     Collection<TimeRange> mandatoryAndOptionalTimesList =
         getMeetingTimes(events, request, /*considerOptionalAttendees=*/true);
-    if (!mandatoryAndOptionalTimesList.isEmpty()) {
+
+    // In the special case where there are no mandatory attendees, at least one optional attendee,
+    // and no times work out, return an empty list rather than considering only mandatory attendees.
+    // This will result in a time range for the whole day and is not desirable.
+    if (!mandatoryAndOptionalTimesList.isEmpty()
+        || request.getAttendees().isEmpty() && !request.getOptionalAttendees().isEmpty()) {
       return mandatoryAndOptionalTimesList;
-    }
-    if (request.getAttendees().isEmpty() && !request.getOptionalAttendees().isEmpty()) {
-      return Arrays.asList();
     }
 
     return getMeetingTimes(events, request, /*considerOptionalAttendees=*/false);

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -119,7 +119,7 @@ public final class FindMeetingQuery {
    */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
     Collection<TimeRange> mandatoryAndOptionalTimesList =
-        getMeettingTimes(events, request, /*considerOptionalAttendees=*/true);
+        getMeetingTimes(events, request, /*considerOptionalAttendees=*/true);
     if (!mandatoryAndOptionalTimesList.isEmpty()) {
       return mandatoryAndOptionalTimesList;
     }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -94,7 +94,7 @@ public final class FindMeetingQuery {
 
       // Only move reference points of end of last event if the cur event end point is later
       // than the end of the event with the latest end point so far.
-      endOfEarlierEvent = max(endOfEarlierEvent, curEvent.getWhen().end());
+      endOfEarlierEvent = Math.max(endOfEarlierEvent, curEvent.getWhen().end());
     }
 
     return openMeetingTimes;

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -15,6 +15,7 @@
 package com.google.sps;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -24,15 +25,15 @@ import java.util.stream.Collectors;
 
 public final class FindMeetingQuery {
   /**
-   * Returns a boolean based on if at least one participant in the event is also a participant in
-   * the meeting request.
+   * Returns a boolean if at least one participant in the event is also a meeting attendee from the
+   * mandatory and/or optional attendee list.
    *
    * @param eventAttendeesCopy A copy of the set of attendees in a specific event.
    * @param meetingAttendees The set of attendees in the meeting request.
    * @return True if at least one participant in the set {@code eventAttendees} is also a
    *     participant in {@code meetingAttendees}. False otherwise.
    */
-  private boolean eventParticipantInMeeting(
+  private boolean eventAttendeeIsMeetingAttendee(
       Set<String> eventAttendeesCopy, Collection<String> meetingAttendees) {
     eventAttendeesCopy.retainAll(meetingAttendees);
     if (eventAttendeesCopy.isEmpty()) {
@@ -44,22 +45,46 @@ public final class FindMeetingQuery {
   /**
    * Returns a collection of all meeting times that will work for all attendees' schedules.
    *
-   * <p>The open meeting times are determined by iterating through each event and creating a new
-   * {@code TimeRange} for each range between meetings. If the duration is greater than or equal to
-   * the duration of the requested meeting, that {@code TimeRange} instance is added to the list
-   * {@code openMeetingTimes}. The initial value of {@code endOfEarlierEvent} is set to the start of
-   * the day for convenience when evaluating the first event. Also, the end of day time is appended
-   * as an additional event to the current event list to avoid more conditional statements.
+   * <p>Initially, the meeting attendees is set based on {@code considerOptionalAttendees}. Once
+   * this is determined, the event list is filtered and sorted. More specifically, the events are
+   * filtered if it does not contain at least one participant that is also a meeting participant.
+   * The open meeting times are determined by iterating through each event and creating a new {@code
+   * TimeRange} for each range between meetings. If the duration is greater than or equal to the
+   * duration of the requested meeting, that {@code TimeRange} instance is added to the list {@code
+   * openMeetingTimes}. The initial value of {@code endOfEarlierEvent} is set to the start of the
+   * day for convenience when evaluating the first event. Also, the end of day time is appended as
+   * an additional event to the current event list to avoid more conditional statements.
    *
    * @param eventList The list of events that are used to determine what periods of time that the
    *     meeting can take place. This list is 'filtered' and sorted in {@code query()}.
    * @param request The meeting request that contains the requirements for potential meetings.
    * @return A Collection of the feasible meeting {@code TimeRange}s.
    */
-  private Collection<TimeRange> getMeettingTimes(List<Event> eventList, MeetingRequest request) {
+  private Collection<TimeRange> getMeettingTimes(
+      Collection<Event> events, MeetingRequest request, boolean considerOptionalAttendees) {
+    Collection<String> meetingAttendees = new HashSet<String>(request.getAttendees());
+    if (considerOptionalAttendees) {
+      meetingAttendees.addAll(request.getOptionalAttendees());
+    }
+    System.out.println(meetingAttendees);
+
+    List<Event> eventList =
+        events.stream()
+            .filter(
+                event ->
+                    eventAttendeeIsMeetingAttendee(
+                        new HashSet<String>(event.getAttendees()), meetingAttendees))
+            .sorted(
+                new Comparator<Event>() {
+                  @Override
+                  public int compare(Event a, Event b) {
+                    return Long.compare(a.getWhen().start(), b.getWhen().start());
+                  }
+                })
+            .collect(Collectors.toList());
+
     eventList.add(
-        new Event(
-            "EOD", TimeRange.fromStartDuration(TimeRange.END_OF_DAY, 0), request.getAttendees()));
+        new Event("EOD", TimeRange.fromStartDuration(TimeRange.END_OF_DAY, 0), meetingAttendees));
     int endOfEarlierEvent = TimeRange.START_OF_DAY;
 
     Collection<TimeRange> openMeetingTimes = new ArrayList<>();
@@ -86,13 +111,13 @@ public final class FindMeetingQuery {
   }
 
   /**
-   * Returns a collection of all meeting times that will work for all attendees' schedules.
+   * Returns a collection of all meeting times that will work for attendees' schedules.
    *
-   * <p>To determine the meeting times ({@code TimeRange}s) that works for all attendees, the event
-   * list is filtered and sorted so that {@code getMeetingTimes()} can determine all feasible
-   * meeting times. More specifically, filtered means that an event is removed if it does not
-   * contain at least one participant that is included in the meeting request. Both filtering and
-   * then sorting are accomplished using a stream of Event objects.
+   * <p>Initially, meeting times ({@code TimeRange}s) that will works for both mandatory and
+   * optional attendies are identified. If there are no meeting times that work for all attendees,
+   * only meeting times with mandatory attendees are identified and returned. In the special case
+   * where there are no mandatory attendees, at least one optional attendee, and no times work out,
+   * return an empty list.
    *
    * @param events The Collection of events that are used to determine what periods of time that the
    *     meeting can take place.
@@ -100,20 +125,14 @@ public final class FindMeetingQuery {
    * @return A Collection of the feasible meeting {@code TimeRange}s.
    */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    List<Event> eventList =
-        events.stream()
-            .filter(
-                event -> eventParticipantInMeeting(
-                    new HashSet<String>(event.getAttendees()), request.getAttendees()))
-            .sorted(
-                new Comparator<Event>() {
-                  @Override
-                  public int compare(Event a, Event b) {
-                    return Long.compare(a.getWhen().start(), b.getWhen().start());
-                  }
-                })
-            .collect(Collectors.toList());
+    Collection<TimeRange> mandatoryAndOptionalTimesList = getMeettingTimes(events, request, true);
+    if (!mandatoryAndOptionalTimesList.isEmpty()) {
+      return mandatoryAndOptionalTimesList;
+    }
+    if (request.getAttendees().isEmpty() && !request.getOptionalAttendees().isEmpty()) {
+      return Arrays.asList();
+    }
 
-    return getMeettingTimes(eventList, request);
+    return getMeettingTimes(events, request, false);
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -34,6 +34,7 @@ public final class FindMeetingQueryTest {
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
   private static final String PERSON_B = "Person B";
+  private static final String PERSON_C = "Person C";
 
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
@@ -42,7 +43,9 @@ public final class FindMeetingQueryTest {
   private static final int TIME_0930AM = TimeRange.getTimeInMinutes(9, 30);
   private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
   private static final int TIME_1100AM = TimeRange.getTimeInMinutes(11, 00);
+  private static final int TIME_1200PM = TimeRange.getTimeInMinutes(12, 00);
 
+  private static final int DURATION_15_MINUTES = 15;
   private static final int DURATION_30_MINUTES = 30;
   private static final int DURATION_60_MINUTES = 60;
   private static final int DURATION_90_MINUTES = 90;
@@ -56,6 +59,7 @@ public final class FindMeetingQueryTest {
     query = new FindMeetingQuery();
   }
 
+  // Mandatory attendees only tests.
   @Test
   public void optionsForNoAttendees() {
     MeetingRequest request = new MeetingRequest(NO_ATTENDEES, DURATION_1_HOUR);
@@ -270,5 +274,180 @@ public final class FindMeetingQueryTest {
 
     Assert.assertEquals(expected, actual);
   }
+
+  // Mandatory and optional attendee tests.
+  @Test
+  public void onlyMandatoryAttendeesAreConsidered() {
+    // Have each person have different events. We should see three options because the mandattory 
+    // attendee's have non-overlapping events while the optional attendee is not available at
+    // any point in the day.
+    //
+    // Events  :       |--A--|     |--B--|
+    //           |--------------C--------------|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, 
+                                                    TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void mandatoryAndOptionalAttendeesConsidered() {
+    // Have each person have different events. We should see two options because each person has
+    // non-overlapping events that split the day into two open sections of time. The time between
+    // the mandatory attendees (A & B) was considered but removed because there existed other 
+    // time slots such that both mandatory and optional attendees (C) could attend.
+    //
+    // Events  :       |--A--|--C--|--B--|
+    // Day     : |-----------------------------|
+    // Options : |--1--|                 |--3--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void justEnoughRoomForMandatoryOnly() {
+    // Have one mandatory (A) and one optional (B) attendee. There is just enough time at one point
+    // in the day for A to attend the meeting while B is busy during that time. Even though B 
+    // attend, the meeting is scheduled because it is the only time mandatorry attendees can make.
+    //
+    // Events  : |--A--|-B-| |----A----|
+    // Day     : |---------------------|
+    // Options :       |-----|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM, DURATION_15_MINUTES),
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void variousEventsOnlyOptionalAttendees() {
+    // Have an event for each (3) optional person that will allow for three open time slot options.
+    //
+    // Events  :     |-A-|    |-C-|
+    //                |-B-|
+    // Day     : |---------------------|
+    // Options : |-1-|    |-2-|   |-3--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_60_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_1100AM, DURATION_60_MINUTES),
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request = new MeetingRequest(NO_ATTENDEES, DURATION_60_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TIME_1100AM, false),
+            TimeRange.fromStartEnd(TIME_1200PM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void notEnoughRoomOnlyOptionalAttendees() {
+    // Same as notEnoughRoom() but with two optional attendees.
+    // Have one person, but make it so that there is not enough room at any point in the day to
+    // have the meeting.
+    //
+    // Events  : |---A----| |----B-----|
+    // Day     : |---------------------|
+    // Options :
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(NO_ATTENDEES, DURATION_60_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList();
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void ignoresMandatoryPeopleNotAttending() {
+    // Same as ignoresPeopleNotAttending(), except the person that is looking to book is an
+    // optional attendee (B) with an event in a timeslot that the mandatory (A) guest would 
+    // not be able to attend if they were invited to the meeting.
+    //
+    // Events  : |---B---||-----A------|
+    // Day     : |---------------------|
+    // Options :         |-------------|
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0930AM, false),
+            Arrays.asList(PERSON_B)));
+    MeetingRequest request = new MeetingRequest(NO_ATTENDEES, DURATION_60_MINUTES);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = 
+        Arrays.asList(TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+  
 }
 

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -14,11 +14,9 @@
 
 package com.google.sps;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -91,9 +89,9 @@ public final class FindMeetingQueryTest {
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-            TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true));
+    Collection<TimeRange> expected = Arrays.asList(
+        TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusive=*/false),
+        TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, /*inclusive=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -117,10 +115,10 @@ public final class FindMeetingQueryTest {
         new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
-            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
-            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+    Collection<TimeRange> expected = Arrays.asList(
+        TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, /*inclusive=*/false),
+        TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, /*inclusive=*/false),
+        TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, /*inclusive=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -144,9 +142,9 @@ public final class FindMeetingQueryTest {
         new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-            TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
+    Collection<TimeRange> expected = Arrays.asList(
+        TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusive=*/false),
+        TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, /*inclusive=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -171,9 +169,9 @@ public final class FindMeetingQueryTest {
         new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-            TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
+    Collection<TimeRange> expected = Arrays.asList(
+        TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusive=*/false),
+        TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, /*inclusive=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -196,9 +194,9 @@ public final class FindMeetingQueryTest {
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+    Collection<TimeRange> expected = Arrays.asList(
+        TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusive=*/false),
+        TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, /*inclusive=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -213,9 +211,11 @@ public final class FindMeetingQueryTest {
     // Options :       |-----|
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        new Event("Event 1",
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusive=*/false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+        new Event("Event 2",
+            TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, /*inclusive=*/true),
             Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
@@ -262,9 +262,11 @@ public final class FindMeetingQueryTest {
     // Options :
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        new Event("Event 1",
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusive=*/false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+        new Event("Event 2",
+            TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, /*inclusive=*/true),
             Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
@@ -278,8 +280,8 @@ public final class FindMeetingQueryTest {
   // Mandatory and optional attendee tests.
   @Test
   public void onlyMandatoryAttendeesAreConsidered() {
-    // Have each person have different events. We should see three options because the mandatory 
-    // attendee's (A & B) have non-overlapping events while the optional attendee (C) is not 
+    // Have each person have different events. We should see three options because the mandatory
+    // attendee's (A & B) have non-overlapping events while the optional attendee (C) is not
     // available at any point in the day.
     //
     // Events  :       |--A--|     |--B--|
@@ -292,8 +294,9 @@ public final class FindMeetingQueryTest {
             Arrays.asList(PERSON_A)),
         new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
             Arrays.asList(PERSON_B)),
-        new Event("Event 3", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, 
-                                                    TimeRange.END_OF_DAY, true),
+        new Event("Event 3",
+            TimeRange.fromStartEnd(
+                TimeRange.START_OF_DAY, TimeRange.END_OF_DAY, /*inclusive=*/true),
             Arrays.asList(PERSON_C)));
 
     MeetingRequest request =
@@ -301,10 +304,10 @@ public final class FindMeetingQueryTest {
     request.addOptionalAttendee(PERSON_C);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
-            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
-            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+    Collection<TimeRange> expected = Arrays.asList(
+        TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, /*inclusive=*/false),
+        TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, /*inclusive=*/false),
+        TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, /*inclusive=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -313,7 +316,7 @@ public final class FindMeetingQueryTest {
   public void mandatoryAndOptionalAttendeesConsidered() {
     // Have each person have different events. We should see two options because each person has
     // non-overlapping events that split the day into two open sections of time. The time between
-    // the mandatory attendees (A & B) was considered but removed because there existed other 
+    // the mandatory attendees (A & B) was considered but removed because there existed other
     // time slots such that both mandatory and optional attendees (C) could attend.
     //
     // Events  :       |--A--|--C--|--B--|
@@ -333,9 +336,9 @@ public final class FindMeetingQueryTest {
     request.addOptionalAttendee(PERSON_C);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
-            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+    Collection<TimeRange> expected = Arrays.asList(
+        TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, /*inclusive=*/false),
+        TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, /*inclusive=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -343,7 +346,7 @@ public final class FindMeetingQueryTest {
   @Test
   public void justEnoughRoomForMandatoryOnly() {
     // Have one mandatory (A) and one optional (B) attendee. There is just enough time at one point
-    // in the day for A to attend the meeting while B is busy during that time. Even though B 
+    // in the day for A to attend the meeting while B is busy during that time. Even though B
     // attend, the meeting is scheduled because it is the only time mandatorry attendees can make.
     //
     // Events  : |--A--|-B-| |----A----|
@@ -351,9 +354,11 @@ public final class FindMeetingQueryTest {
     // Options :       |-----|
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        new Event("Event 1",
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusive=*/false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+        new Event("Event 2",
+            TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, /*inclusive=*/true),
             Arrays.asList(PERSON_A)),
         new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM, DURATION_15_MINUTES),
             Arrays.asList(PERSON_C)));
@@ -391,10 +396,10 @@ public final class FindMeetingQueryTest {
     request.addOptionalAttendee(PERSON_C);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
-            TimeRange.fromStartEnd(TIME_0930AM, TIME_1100AM, false),
-            TimeRange.fromStartEnd(TIME_1200PM, TimeRange.END_OF_DAY, true));
+    Collection<TimeRange> expected = Arrays.asList(
+        TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, /*inclusive=*/false),
+        TimeRange.fromStartEnd(TIME_0930AM, TIME_1100AM, /*inclusive=*/false),
+        TimeRange.fromStartEnd(TIME_1200PM, TimeRange.END_OF_DAY, /*inclusive=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -408,9 +413,11 @@ public final class FindMeetingQueryTest {
     // Options :
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        new Event("Event 1",
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusive=*/false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+        new Event("Event 2",
+            TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, /*inclusive=*/true),
             Arrays.asList(PERSON_B)));
 
     MeetingRequest request = new MeetingRequest(NO_ATTENDEES, DURATION_60_MINUTES);
@@ -426,26 +433,26 @@ public final class FindMeetingQueryTest {
   @Test
   public void ignoresMandatoryPeopleNotAttending() {
     // Same as ignoresPeopleNotAttending(), except the person that is looking to book is an
-    // optional attendee (B) with an event in a timeslot that the mandatory (A) guest would 
+    // optional attendee (B) with an event in a timeslot that the mandatory (A) guest would
     // not be able to attend if they were invited to the meeting.
     //
     // Events  : |---B---||-----A------|
     // Day     : |---------------------|
     // Options :         |-------------|
     Collection<Event> events = Arrays.asList(
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true),
+        new Event("Event 2",
+            TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, /*inclusive=*/true),
             Arrays.asList(PERSON_A)),
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0930AM, false),
+        new Event("Event 1",
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0930AM, /*inclusive=*/false),
             Arrays.asList(PERSON_B)));
     MeetingRequest request = new MeetingRequest(NO_ATTENDEES, DURATION_60_MINUTES);
     request.addOptionalAttendee(PERSON_B);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected = 
-        Arrays.asList(TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+    Collection<TimeRange> expected = Arrays.asList(
+        TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, /*inclusive=*/true));
 
     Assert.assertEquals(expected, actual);
   }
-  
 }
-

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -278,9 +278,9 @@ public final class FindMeetingQueryTest {
   // Mandatory and optional attendee tests.
   @Test
   public void onlyMandatoryAttendeesAreConsidered() {
-    // Have each person have different events. We should see three options because the mandattory 
-    // attendee's have non-overlapping events while the optional attendee is not available at
-    // any point in the day.
+    // Have each person have different events. We should see three options because the mandatory 
+    // attendee's (A & B) have non-overlapping events while the optional attendee (C) is not 
+    // available at any point in the day.
     //
     // Events  :       |--A--|     |--B--|
     //           |--------------C--------------|
@@ -402,8 +402,6 @@ public final class FindMeetingQueryTest {
   @Test
   public void notEnoughRoomOnlyOptionalAttendees() {
     // Same as notEnoughRoom() but with two optional attendees.
-    // Have one person, but make it so that there is not enough room at any point in the day to
-    // have the meeting.
     //
     // Events  : |---A----| |----B-----|
     // Day     : |---------------------|


### PR DESCRIPTION
Add functionality to handle optional meeting attendees in the 'Find Meeting Times' algorithm.

This algorithm improved upon the implementation of the query method and related helper functions in the FindMeetingQuery class. The algorithm's asymptotic time complexity remains the same as mentioned in #27 given the same assumptions. 

The additions to the algorithm:
- Move the filtering and sorting work into `getMeetingTimes()`.
- Add an additional parameter to `getMeetingTimes()` that allows the caller to specify whether the meeting attendees contains all attendees (optional and mandatory) or just mandatory ones.
- In `query()`, first call `getMeetingTimes()` with the option to include all meeting attendees. If the time range list returned is not empty, return that. If not, return the result of `getMeetingTimes()` with the option to include only mandatory meeting attendees. An extra conditional was also inserted between those steps to return an empty list in the case where there are no mandatory attendees, at least one optional attendee, and no times work out.
- Modify documentation to reflect changes.

Tests were written prior to building the implementation to follow TDD. These additional test cases included the ones mentioned [here](https://github.com/googleinterns/step/blob/master/walkthroughs/week-5-tdd/project/calendar-walkthrough.md#writing-more-tests) and one original test case that was similar to `ignoresPeopleNotAttending()` (See final test case in FindMeetingQueryTest.java).